### PR TITLE
Do not blow hatch

### DIFF
--- a/src/main/scala/org/scalacheck/Arbitrary.scala
+++ b/src/main/scala/org/scalacheck/Arbitrary.scala
@@ -143,7 +143,7 @@ object Arbitrary {
   /** Arbitrary instance of Date */
   implicit lazy val arbDate: Arbitrary[Date] = Arbitrary(for {
     l <- arbitrary[Long]
-    val d = new Date
+    d = new Date
   } yield new Date(d.getTime + l))
 
   /** Arbitrary instance of Throwable */

--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -373,7 +373,7 @@ object Gen {
   /** A generator that picks a given number of elements from a list, randomly */
   def pick[T](n: Int, g1: Gen[T], g2: Gen[T], gs: Gen[T]*): Gen[Seq[T]] = for {
     is <- pick(n, 0 until (gs.size+2))
-    val allGs = gs ++ (g1::g2::Nil)
+    allGs = gs ++ (g1::g2::Nil)
     xs <- sequence[List,T](is.toList.map(allGs(_)))
   } yield xs
 

--- a/src/main/scala/org/scalacheck/Pretty.scala
+++ b/src/main/scala/org/scalacheck/Pretty.scala
@@ -86,7 +86,7 @@ object Pretty {
       "> Collected test data: " / {
         for {
           (xs,r) <- fm.getRatios
-          val ys = xs - ()
+          ys = xs - ()
           if !ys.isEmpty
         } yield round(r*100)+"% " + ys.mkString(", ")
       }.mkString("\n")


### PR DESCRIPTION
This reverts commit 3d1377dd8ed5d345d0b053cc5891eb64f6bc0553.

The powers that be love it when people say things like "the least
controversial patch you'll see today" only to have to revert it the
following day.  See scala trunk r25484 for explanation.
