### PR TITLE
Get rid of Scala RCs in crossScalaVersions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ homepage := Some(url("http://www.scalacheck.org"))
 
 scalaVersion := "2.10.0"
 
-crossScalaVersions := Seq("2.9.0", "2.9.0-1", "2.9.1", "2.9.1-1", "2.9.2", "2.10.0-RC4", "2.10.0-RC5", "2.10.0")
+crossScalaVersions := Seq("2.9.0", "2.9.0-1", "2.9.1", "2.9.1-1", "2.9.2", "2.10.0")
 
 mimaDefaultSettings
 


### PR DESCRIPTION
Since Scala final is out we should get rid of RCs altogether.
