### PR TITLE
Make chooseLong generate the full range of Long values

### DIFF
--- a/src/main/scala/org/scalacheck/Arbitrary.scala
+++ b/src/main/scala/org/scalacheck/Arbitrary.scala
@@ -88,7 +88,7 @@ object Arbitrary {
 
   /** Arbitrary instance of Long */
   implicit lazy val arbLong: Arbitrary[Long] = Arbitrary(
-    Gen.chooseNum(Long.MinValue / 2, Long.MaxValue / 2)
+    Gen.chooseNum(Long.MinValue, Long.MaxValue)
   )
 
   /** Arbitrary instance of Float */

--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -23,7 +23,7 @@ object Choose {
 
   implicit val chooseLong: Choose[Long] = new Choose[Long] {
     def choose(low: Long, high: Long) =
-      if(low > high || (high-low < 0)) fail
+      if (low > high) fail
       else parameterized(prms => value(prms.choose(low,high)))
   }
 
@@ -204,9 +204,17 @@ object Gen {
     /** @throws IllegalArgumentException if l is greater than h, or if
      *  the range between l and h doesn't fit in a Long. */
     def choose(l: Long, h: Long): Long = {
-      val d = h-l
-      if (d < 0) throw new IllegalArgumentException("Invalid range")
-      else l + math.abs(rng.nextLong % (d+1))
+      if (h < l) throw new IllegalArgumentException("Invalid range")
+      val d = h - l + 1
+      if (d <= 0) {
+        var n = rng.nextLong
+        while (n < l || n > h) {
+          n = rng.nextLong
+        }
+        n
+      } else {
+        l + math.abs(rng.nextLong % d)
+      }
     }
 
     /** @throws IllegalArgumentException if l is greater than h, or if

--- a/src/test/scala/org/scalacheck/GenSpecification.scala
+++ b/src/test/scala/org/scalacheck/GenSpecification.scala
@@ -15,7 +15,6 @@ import Arbitrary._
 import Shrink._
 
 object GenSpecification extends Properties("Gen") {
-
   property("sequence") =
     forAll(listOf(frequency((10,value(arbitrary[Int])),(1,value(fail)))))(l =>
       (someFailing(l) && (sequence[List,Int](l) == fail)) ||
@@ -36,7 +35,7 @@ object GenSpecification extends Properties("Gen") {
   }
 
   property("choose-long") = forAll { (l: Long, h: Long) =>
-    if(l > h || h-l < 0) choose(l,h) == fail
+    if (l > h) choose(l,h) == fail
     else forAll(choose(l,h)) { x => x >= l && x <= h }
   }
 


### PR DESCRIPTION
I was testing a function that was supposed to work over the full range of values with chooseNum(Long.MinValue, Long.MaxValue) and I ended up with too many rejected values in the generator. This change makes Arbitrary[Long] generate the full range of Long values. The previous implementation was restricted to (Long.MinValue / 2, Long.MaxValue / 2).
