### PR TITLE
fix warnings on try-catch

### DIFF
--- a/src/main/scala/org/scalacheck/Prop.scala
+++ b/src/main/scala/org/scalacheck/Prop.scala
@@ -401,7 +401,7 @@ object Prop {
 
   /** Wraps and protects a property */
   def secure[P <% Prop](p: => P): Prop =
-    try { p: Prop } catch { case e => exception(e) }
+    try { p: Prop } catch { case e: Throwable => exception(e) }
 
   /** Existential quantifier for an explicit generator. */
   def exists[A,P](f: A => P)(implicit

--- a/src/main/scala/org/scalacheck/Test.scala
+++ b/src/main/scala/org/scalacheck/Test.scala
@@ -200,7 +200,7 @@ object Test {
   }
 
   private def secure[T](x: => T): Either[T,Throwable] =
-    try { Left(x) } catch { case e => Right(e) }
+    try { Left(x) } catch { case e: Throwable => Right(e) }
 
   private[scalacheck] lazy val cmdLineParser = new CmdLineParser {
     object OptMinSuccess extends IntOpt {


### PR DESCRIPTION
This commit removes the following warnings:

[warn] /Users/mikeg/workspace/scalacheck/src/main/scala/org/scalacheck/Prop.scala:404: This catches all Throwables. If this is really intended, use `case e : Throwable` to clear this warning.
[warn]     try { p: Prop } catch { case e => exception(e) }
[warn]                                  ^
[warn] /Users/mikeg/workspace/scalacheck/src/main/scala/org/scalacheck/Test.scala:203: This catches all Throwables. If this is really intended, use `case e : Throwable` to clear this warning.
[warn]     try { Left(x) } catch { case e => Right(e) }
