### PR TITLE
Enable fingerprint for non-module Prop

### DIFF
--- a/src/main/scala/org/scalacheck/ScalaCheckFramework.scala
+++ b/src/main/scala/org/scalacheck/ScalaCheckFramework.scala
@@ -27,7 +27,7 @@ class ScalaCheckFramework extends Framework {
 
   val name = "ScalaCheck"
 
-  val tests = Array[Fingerprint](PropsFingerprint, PropsFingerprint)
+  val tests = Array[Fingerprint](PropFingerprint, PropsFingerprint)
 
   def testRunner(loader: ClassLoader,  loggers: Array[Logger]) = new Runner2 {
 


### PR DESCRIPTION
`Framework.tests` appears to have a typo that disables detection of tests
that aren't modules.  Maybe that's intentional.

Probably every test in existence is a module extending Properties.

The ! line doesn't include the class name as property name. And the count is 2 instead of 1.

From sbt, `No main class detected.`

I'm exercising test-interface from partest, but this is not a need-driven PR.
