### PR TITLE
Switch to modularized parser combinators 1.0-RC2.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ libraryDependencies <++= (scalaVersion){sVer =>
 
 libraryDependencies <++= (scalaVersion){sVer =>
   if((sVer startsWith "2.9") || (sVer startsWith "2.10")) Seq.empty
-  else Seq("org.scala-lang" % "scala-parser-combinators" % sVer)
+  else Seq("org.scala-lang.modules" %% "scala-parser-combinators" % "1.0-RC2")
 }
 
 javacOptions ++= Seq("-Xmx1024M")


### PR DESCRIPTION
With Scala 2.11.0-M5, the parser combinators are now a separate module.
I'm publishing 1.0-RC2 now, and verified scalacheck compiles against it:

``` bash
sbt12 'set version := "1.10.1"' \
'set scalaVersion := "2.11.0-M5"' \
'set every scalaBinaryVersion := "2.11.0-M5"' \
publish-local
```

Could you please release a release of 1.10.1 against 2.11.0-M5 using this PR?
That way we can publish partest. /cc @gkossakowski
