### PR TITLE
replace bespoke collection Buildables with a single one that uses the CanBuildFrom machinery

### DIFF
--- a/src/main/scala/org/scalacheck/util/Buildable.scala
+++ b/src/main/scala/org/scalacheck/util/Buildable.scala
@@ -31,41 +31,12 @@ trait Buildable2[T,U,C[_,_]] {
 }
 
 object Buildable {
+  import generic.CanBuildFrom
 
-  implicit def buildableList[T] = new Buildable[T,List] {
-    def builder = List.newBuilder
-  }
-
-  implicit def buildableStream[T] = new Buildable[T,Stream] {
-    def builder = Stream.newBuilder
-  }
-
-  // TODO: Change ClassManifest to ClassTag when support for Scala 2.9.x can
-  // be dropped
-
-  implicit def buildableArray[T : reflect.ClassManifest] = new Buildable[T,Array] {
-    def builder = mutable.ArrayBuilder.make[T]
-  }
-
-  implicit def buildableMutableSet[T] = new Buildable[T,mutable.Set] {
-    def builder = mutable.Set.newBuilder
-  }
-
-  implicit def buildableImmutableSet[T] = new Buildable[T,Set] {
-    def builder = new mutable.SetBuilder(Set.empty[T])
-  }
-
-  implicit def buildableImmutableSortedSet[T: Ordering] = new Buildable[T,immutable.SortedSet] {
-    def builder = immutable.SortedSet.newBuilder
-  }
-
-  implicit def buildableSet[T] = new Buildable[T,Set] {
-    def builder = Set.newBuilder
-  }
-
-  implicit def buildableSortedSet[T: Ordering] = new Buildable[T,SortedSet] {
-    def builder = SortedSet.newBuilder
-  }
+  implicit def buildableCanBuildFrom[T, C[_]](implicit c: CanBuildFrom[C[_], T, C[T]]) = 
+    new Buildable[T, C] {
+      def builder = c.apply
+    }
 
   import java.util.ArrayList
   implicit def buildableArrayList[T] = new Buildable[T,ArrayList] {

--- a/src/test/scala/org/scalacheck/util/BuildableSpecification.scala
+++ b/src/test/scala/org/scalacheck/util/BuildableSpecification.scala
@@ -1,0 +1,44 @@
+/*-------------------------------------------------------------------------*\
+**  ScalaCheck                                                             **
+**  Copyright (c) 2007-2013 Rickard Nilsson. All rights reserved.          **
+**  http://www.scalacheck.org                                              **
+**                                                                         **
+**  This software is released under the terms of the Revised BSD License.  **
+**  There is NO WARRANTY. See the file LICENSE for the full text.          **
+\*------------------------------------------------------------------------ */
+
+package org.scalacheck
+package util
+
+import collection._
+
+object BuildableSpecification {
+  def container[C[_]](implicit ev: Buildable[String, C]) =
+    Gen.containerOf[C, String](Gen.alphaStr)
+
+  implicit val listGen: Gen[List[String]] = container[List]
+
+  implicit val streamGen: Gen[Stream[String]] = container[Stream]
+
+  implicit val arrayGen: Gen[Array[String]] = container[Array]
+
+  implicit val mutableSetGen: Gen[mutable.Set[String]] = container[mutable.Set]
+
+  implicit val setGen: Gen[Set[String]] = container[Set]
+    
+  implicit val immutableSortedSetGen: Gen[immutable.SortedSet[String]] = container[immutable.SortedSet]
+
+  implicit val vectorGen: Gen[Vector[String]] = container[Vector]
+
+  implicit val treeSetGen: Gen[immutable.TreeSet[String]] = container[immutable.TreeSet]
+
+  implicit val hashSetGen: Gen[immutable.HashSet[String]] = container[immutable.HashSet]
+
+  implicit val indexedSeqGen: Gen[immutable.IndexedSeq[String]] = container[immutable.IndexedSeq]
+
+  implicit val seqGen: Gen[immutable.Seq[String]] = container[immutable.Seq]
+
+  implicit val iterableGen: Gen[immutable.Iterable[String]] = container[immutable.Iterable]
+
+  implicit val trieIteratorGen: Gen[immutable.Queue[String]] = container[immutable.Queue]
+}


### PR DESCRIPTION
addresses:
https://github.com/rickynils/scalacheck/issues/57
https://github.com/rickynils/scalacheck/issues/58
