### PR TITLE
Facilitate automating release. Enable Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: scala
+script:
+  - sbt ++$TRAVIS_SCALA_VERSION clean update compile test
+scala:
+  - 2.11.0-M6
+jdk:
+  - oraclejdk6
+  - openjdk7
+notifications:
+  email:
+    - adriaan.moors@typesafe.com
+
+# if we get weird timeouts, see https://github.com/spray/spray/pull/233
+# 'set concurrentRestrictions in Global += Tags.limit(Tags.Test, 1)'

--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,8 @@ import com.typesafe.tools.mima.plugin.MimaPlugin.mimaDefaultSettings
 
 import com.typesafe.tools.mima.plugin.MimaKeys.previousArtifact
 
+import VersionKeys.scalaParserCombinatorsVersion
+
 name := "scalacheck"
 
 version := "1.11.0"
@@ -14,7 +16,9 @@ homepage := Some(url("http://www.scalacheck.org"))
 
 scalaVersion := "2.10.3"
 
-crossScalaVersions := Seq("2.9.3", "2.10.3", "2.11.0-M5")
+scalaParserCombinatorsVersion := "1.0.0-RC4"
+
+crossScalaVersions := Seq("2.9.3", "2.10.3", "2.11.0-M6")
 
 mimaDefaultSettings
 
@@ -24,7 +28,7 @@ libraryDependencies += "org.scala-sbt" %  "test-interface" % "1.0"
 
 libraryDependencies ++= (
   if((scalaVersion.value startsWith "2.9") || (scalaVersion.value startsWith "2.10")) Seq.empty
-  else Seq("org.scala-lang.modules" %% "scala-parser-combinators" % "1.0-RC2")
+  else Seq("org.scala-lang.modules" %% "scala-parser-combinators" % scalaParserCombinatorsVersion.value)
 )
 
 javacOptions ++= Seq("-Xmx1024M")

--- a/project/versions.scala
+++ b/project/versions.scala
@@ -1,0 +1,5 @@
+object VersionKeys {
+  import sbt.settingKey
+
+  val scalaParserCombinatorsVersion = settingKey[String]("The version of the Scala Parser Combinators to use.")
+}


### PR DESCRIPTION
This factors out the version of scala-parser-combinators to build against
as `scalaParserCombinatorsVersion`, so that builds/releases can be automated
as follows:

```
     SCALA_VER="2.11.0-M7"
   PARSERS_VER="1.0.0-RC5"
SCALACHECK_VER="1.11.0"

sbt 'set version := "'$SCALACHECK_VER'"' \
    'set scalaVersion := "'$SCALA_VER'"' \
    'set every scalaBinaryVersion := "'$SCALA_VER'"' \
    'set VersionKeys.scalaParserCombinatorsVersion := "'$PARSERS_VER'"' \
    clean test publish-signed
```

It also enables Travis CI -- currently only testing against M6 on Java 6&7.
I'd like to propose building against Scala 2.11.0-SNAPSHOT soon.
(We're implementing/trial running this first at scala/scala-xml and the other modules)
