### PR TITLE
Add Choose.xmap

### DIFF
--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -277,6 +277,14 @@ object Gen {
       def choose(low: Float, high: Float) =
         gen(chDbl(low,high)).map(_.toFloat).suchThat(x => x >= low && x <= high)
     }
+
+    /** Transform a Choose[T] to a Choose[U] where T and U are two isomorphic types
+     *  whose relationship is described by the provided transformation functions.
+     *  (exponential functor map) */
+    def xmap[T, U](from: T => U, to: U => T)(implicit c: Choose[T]): Choose[U] = new Choose[U] {
+      def choose(low: U, high: U) =
+        c.choose(to(low), to(high)).map(from)
+    }
   }
 
 

--- a/src/test/scala/org/scalacheck/GenSpecification.scala
+++ b/src/test/scala/org/scalacheck/GenSpecification.scala
@@ -13,6 +13,7 @@ import Gen._
 import Prop.{forAll, someFailing, noneFailing, sizedProp}
 import Arbitrary._
 import Shrink._
+import java.util.Date
 
 object GenSpecification extends Properties("Gen") {
   property("sequence") =
@@ -58,6 +59,14 @@ object GenSpecification extends Properties("Gen") {
   property("choose-double") = forAll { (l: Double, h: Double) =>
     if(l > h || h-l > Double.MaxValue) choose(l,h) == fail
     else forAll(choose(l,h)) { x => x >= l && x <= h }
+  }
+
+  property("choose-xmap") = {
+    implicit val chooseDate = Choose.xmap[Long, Date](new Date(_), _.getTime)
+    forAll { (l: Date, h: Date) =>
+      if(l.after(h)) choose(l, h) == fail
+      else forAll(choose(l,h)) { x => x.compareTo(l) >= 0 && x.compareTo(h) <= 0 }
+    }
   }
 
   property("parameterized") = forAll((g: Gen[Int]) => parameterized(p=>g) == g)


### PR DESCRIPTION
Choose.iso provides a simple way to create a Choose instances from an
isomorphic type with a Choose instance. For example, to create a
Choose[Date] based on the existing Choose[Long], one could write:

``` scala
implicit val chooseDate = Choose.iso[Long, Date](new Date(_), _.getTime)
```

I've found myself wanting this functionality when creating Choose instances for Joda DateTime, FiniteDuration, etc.
