### PR TITLE
Add xmap to Shrink

### DIFF
--- a/src/main/scala/org/scalacheck/Shrink.scala
+++ b/src/main/scala/org/scalacheck/Shrink.scala
@@ -206,4 +206,10 @@ object Shrink {
       shrink(t9).map((t1, t2, t3, t4, t5, t6, t7, t8, _))
     }
 
+  /** Transform a Shrink[T] to a Shrink[U] where T and U are two isomorphic types
+    *  whose relationship is described by the provided transformation functions.
+    *  (exponential functor map) */
+  def xmap[T, U](from: T => U, to: U => T)(implicit st: Shrink[T]): Shrink[U] = Shrink[U] { u: U ⇒
+    st.shrink(to(u)).map(from)
+  }
 }

--- a/src/test/scala/org/scalacheck/ShrinkSpecification.scala
+++ b/src/test/scala/org/scalacheck/ShrinkSpecification.scala
@@ -39,4 +39,11 @@ object ShrinkSpecification extends Properties("Shrink") {
     }
   }
 
+  implicit def vectorShrink[A: Shrink] = Shrink.xmap[List[A],Vector[A]](_.toVector, _.toList)
+  property("xmap vector from list") = forAll { v: Vector[Int] ⇒
+    (!v.isEmpty && v != Vector(0)) ==> {
+      val vs = shrinkClosure(v)
+      vs.toVector.toString |: (vs.contains(Vector.empty) && vs.contains(Vector(0)))
+    }
+  }
 }


### PR DESCRIPTION
Inspired by the recent commit from @ceedubs [1] which adds xmap to Choose, this

commit adds a similar xmap to Shrink which provides a way to create a Shink
instance from an existing Shrink instance of an isomorphic type

[1] https://github.com/rickynils/scalacheck/commit/c87978b52a8ce11a519fdf30ad543eda60d47507
