### PR TITLE
Specify return types explicitly

### DIFF
--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -107,7 +107,7 @@ sealed trait Gen[+T] {
   }
 
   /** Put a label on the generator to make test reports clearer */
-  def label(l: String) = new Gen[T] {
+  def label(l: String): Gen[T] = new Gen[T] {
     def doApply(p: P) = {
       val r = Gen.this.doApply(p)
       r.copy(l = r.labels + l)

--- a/src/main/scala/org/scalacheck/Test.scala
+++ b/src/main/scala/org/scalacheck/Test.scala
@@ -196,7 +196,7 @@ object Test {
     /** Called whenever a property has finished testing */
     def onTestResult(name: String, result: Result): Unit = ()
 
-    def chain(testCallback: TestCallback) = new TestCallback {
+    def chain(testCallback: TestCallback): TestCallback = new TestCallback {
       override def onPropEval(name: String, threadIdx: Int,
         succeeded: Int, discarded: Int
       ): Unit = {

--- a/src/main/scala/org/scalacheck/util/FreqMap.scala
+++ b/src/main/scala/org/scalacheck/util/FreqMap.scala
@@ -13,7 +13,7 @@ trait FreqMap[T] {
   protected val underlying: scala.collection.immutable.Map[T,Int]
   val total: Int
 
-  def +(t: T) = new FreqMap[T] {
+  def +(t: T): FreqMap[T] = new FreqMap[T] {
     private val n = FreqMap.this.underlying.get(t) match {
       case None => 1
       case Some(n) => n+1
@@ -22,7 +22,7 @@ trait FreqMap[T] {
     val total = FreqMap.this.total + 1
   }
 
-  def -(t: T) = new FreqMap[T] {
+  def -(t: T): FreqMap[T] = new FreqMap[T] {
     val underlying = FreqMap.this.underlying.get(t) match {
       case None => FreqMap.this.underlying
       case Some(n) => FreqMap.this.underlying + (t -> (n-1))
@@ -30,7 +30,7 @@ trait FreqMap[T] {
     val total = FreqMap.this.total + 1
   }
 
-  def ++(fm: FreqMap[T]) = new FreqMap[T] {
+  def ++(fm: FreqMap[T]): FreqMap[T] = new FreqMap[T] {
     private val keys = FreqMap.this.underlying.keySet ++ fm.underlying.keySet
     private val mappings = keys.toStream.map { x =>
       (x, fm.getCount(x).getOrElse(0) + FreqMap.this.getCount(x).getOrElse(0))
@@ -39,7 +39,7 @@ trait FreqMap[T] {
     val total = FreqMap.this.total + fm.total
   }
 
-  def --(fm: FreqMap[T]) = new FreqMap[T] {
+  def --(fm: FreqMap[T]): FreqMap[T] = new FreqMap[T] {
     val underlying = FreqMap.this.underlying transform {
       case (x,n) => n - fm.getCount(x).getOrElse(0)
     }
@@ -58,7 +58,7 @@ trait FreqMap[T] {
 }
 
 object FreqMap {
-  def empty[T] = new FreqMap[T] {
+  def empty[T]: FreqMap[T] = new FreqMap[T] {
     val underlying = scala.collection.immutable.Map.empty[T,Int]
     val total = 0
   }

--- a/src/main/scala/org/scalacheck/util/Pretty.scala
+++ b/src/main/scala/org/scalacheck/util/Pretty.scala
@@ -32,7 +32,7 @@ object Pretty {
 
   val defaultParams = Params(0)
 
-  def apply(f: Params => String) = new Pretty { def apply(p: Params) = f(p) }
+  def apply(f: Params => String): Pretty = new Pretty { def apply(p: Params) = f(p) }
 
   def pretty[T <% Pretty](t: T, prms: Params): String = t(prms)
 


### PR DESCRIPTION
Some methods return anonymous class because it doesn't have return type annotation.
