### PR TITLE
Add an optional name prefix to Properties.include().

### DIFF
--- a/src/main/scala/org/scalacheck/Properties.scala
+++ b/src/main/scala/org/scalacheck/Properties.scala
@@ -71,8 +71,9 @@ class Properties(val name: String) extends Prop {
     }
   }
 
-  /** Adds all properties from another property collection to this one. */
-  def include(ps: Properties) = for((n,p) <- ps.properties) property(n) = p
+  /** Adds all properties from another property collection to this one.
+   *  An optional prefix can be prepended to each included property's name. */
+  def include(ps: Properties, prefix: String = "") = for((n,p) <- ps.properties) property(prefix + n) = p
 
   /** Used for specifying properties. Usage:
    *  {{{


### PR DESCRIPTION
This is useful when Properties with generic property names are included,
but are better described by the "parent" Properties object. That is,
include() without a prefix is a pure import facility, but with a prefix
it models a more hierarchical property structure.

This would replace a common helper function seen in various projects
like scalaz:

```
def checkAll(name: String, props: Properties) =
  for ((name2, prop) <- props.properties) yield {
    property(name + ":" + name2) = prop
  }
```
