### PR TITLE
Break the include method for better binary backward compatibility

### DIFF
--- a/src/main/scala/org/scalacheck/Properties.scala
+++ b/src/main/scala/org/scalacheck/Properties.scala
@@ -71,9 +71,14 @@ class Properties(val name: String) extends Prop {
     }
   }
 
-  /** Adds all properties from another property collection to this one.
-   *  An optional prefix can be prepended to each included property's name. */
-  def include(ps: Properties, prefix: String = "") = for((n,p) <- ps.properties) property(prefix + n) = p
+  /** Adds all properties from another property collection to this one */
+  def include(ps: Properties): Unit =
+    include(ps, prefix = "")
+
+  /** Adds all properties from another property collection to this one
+   *  with a prefix this is prepended to each included property's name. */
+  def include(ps: Properties, prefix: String): Unit =
+    for((n,p) <- ps.properties) property(prefix + n) = p
 
   /** Used for specifying properties. Usage:
    *  {{{


### PR DESCRIPTION
Hi Richard,

Scalachek is used by numerous projects, especially in conjunction with Scalaz and I had some run-time errors when running the latest specs2 version, which depends on ScalaCheck 1.12.0 and the Scalaz-ScalaCheck bindings to test laws in Scalaz because of the new include method.

Breaking it in 2 should solve the problem. That would be nice if you could publish this as 1.12.1 when you have a minute.

Thanks.

cc/ @larsrh
