### PR TITLE
add Arbitrary#fromFunction. more convenient way to define Arbitrary instances

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -57,6 +57,13 @@ lazy val sharedSettings = mimaDefaultSettings ++ Seq(
         <name>Rickard Nilsson</name>
       </developer>
     </developers>
+  },
+
+  sourceGenerators in Compile += task{
+    val dir = (sourceManaged in Compile).value
+    val source = dir / "ArbitraryFromFunction.scala"
+    IO.write(source, CodeGenerator.code)
+    Seq(source)
   }
 )
 

--- a/project/CodeGenerator.scala
+++ b/project/CodeGenerator.scala
@@ -1,0 +1,25 @@
+object CodeGenerator {
+
+  private val f = (n: Int) => {
+    val xs = 1 to n
+    val tparams = xs.map("A" + _)
+    s"""
+  final def fromFunction$n[${tparams.mkString(", ")}, Z](f: (${tparams.mkString(", ")}) => Z)(implicit ${tparams.map(t => s"$t: Arbitrary[$t]").mkString(", ")}): Arbitrary[Z] =
+    Arbitrary(for{
+      ${xs.map(i => s"a$i <- A$i.arbitrary").mkString("; ")}
+    }yield f(${xs.map("a" + _).mkString(", ")}))
+
+  final def fromFunction[${tparams.mkString(", ")}, Z](f: (${tparams.mkString(", ")}) => Z)(implicit ${tparams.map(t => s"$t: Arbitrary[$t]").mkString(", ")}): Arbitrary[Z] =
+    fromFunction$n(f)(${tparams.mkString(", ")})"""
+  }
+
+  val code = s"""package org.scalacheck
+
+abstract class ArbitraryFromFunction {
+
+  ${(1 to 22).map(f).mkString("\n")}
+
+}
+"""
+
+}

--- a/src/main/scala/org/scalacheck/Arbitrary.scala
+++ b/src/main/scala/org/scalacheck/Arbitrary.scala
@@ -55,7 +55,7 @@ sealed abstract class Arbitrary[T] {
  *  generators.
  *  </p>
  */
-object Arbitrary {
+object Arbitrary extends ArbitraryFromFunction {
 
   import Gen.{const, choose, sized, frequency, oneOf, buildableOf, resize}
   import collection.{immutable, mutable}


### PR DESCRIPTION
example

```scala
case class Foo(a: Int, b: String)

// before
implicit val fooArbitrary = Arbitrary(for {
  a <- implicitly[Arbitrary[Int]].arbitrary
  b <- implicitly[Arbitrary[String]].arbitrary
} yield Foo(a, b))

// after
implicit val fooArbitrary =
  Arbitrary.fromFunction(Foo.apply _)
```