### PR TITLE
Abortable command sequence

### DIFF
--- a/src/main/scala/org/scalacheck/commands/Commands.scala
+++ b/src/main/scala/org/scalacheck/commands/Commands.scala
@@ -160,13 +160,13 @@ trait Commands {
   }
   
   /** A command sequence that is executed completely even if some commands fail. */
-  def commandSequense(head: Command, tail: Command*) = new CommandSequense(head +: tail, true)
+  def commandSequence(head: Command, tail: Command*) = new CommandSequence(head +: tail, true)
   /** A command sequence that is aborted even if some commands fail. */
-  def abortableCommandSequense(head: Command, tail: Command*) = new CommandSequense(head +: tail, false)
+  def abortableCommandSequence(head: Command, tail: Command*) = new CommandSequence(head +: tail, false)
 
-  case class CommandSequense(commands: Seq[Command], continueOnFailure:Boolean) extends SuccessCommand {
+  case class CommandSequence(commands: Seq[Command], continueOnFailure:Boolean) extends SuccessCommand {
     lazy val headCommand: Command = if (commands.isEmpty) NoOp else commands.head
-    lazy val tailCommands: Command = if (commands.size <= 1) NoOp else new CommandSequense(commands.tail, continueOnFailure)
+    lazy val tailCommands: Command = if (commands.size <= 1) NoOp else new CommandSequence(commands.tail, continueOnFailure)
     type Result = (Try[headCommand.Result], Option[tailCommands.Result])
     def run(sut: Sut): Result = {
       val headResult: Try[headCommand.Result] = try {


### PR DESCRIPTION
This command sequence variant is built upon my pull request https://github.com/rickynils/scalacheck/pull/141 . It allows to create sequences which can be partially executed if any command fails.

Such sequences also add a check that the not executed commands would not change the sut state when they run.