### PR TITLE
Added `delay` and `protect` for delaying execution of properties.

### DIFF
--- a/src/main/scala/org/scalacheck/Prop.scala
+++ b/src/main/scala/org/scalacheck/Prop.scala
@@ -452,9 +452,23 @@ object Prop {
   def classify(c: => Boolean, ifTrue: Any, ifFalse: Any)(prop: Prop): Prop =
     if(c) collect(ifTrue)(prop) else collect(ifFalse)(prop)
 
-  /** Wraps and protects a property */
+  /**
+   * Wraps and protects a property, turning exceptions thrown
+   * by the property into test failures.
+   */
   def secure[P <% Prop](p: => P): Prop =
     try (p: Prop) catch { case e: Throwable => exception(e) }
+
+  /** Wraps a property to delay its evaluation. */
+  def delay(p: => Prop): Prop =
+    Prop(params => p(params))
+
+  /**
+   * Wraps and protects a property, delaying its evaluation
+   * and turning exceptions into test failures.
+   */
+  def protect(p: => Prop): Prop =
+    delay(secure(p))
 
   /** Existential quantifier for an explicit generator. */
   def exists[A,P](f: A => P)(implicit

--- a/src/test/scala/org/scalacheck/PropSpecification.scala
+++ b/src/test/scala/org/scalacheck/PropSpecification.scala
@@ -12,7 +12,7 @@ package org.scalacheck
 import Prop.{
   forAll, falsified, undecided, exception, passed, proved, all,
   atLeastOne, sizedProp, someFailing, noneFailing, Undecided, False, True,
-  Exception, Proof, within, throws, BooleanOperators
+  Exception, Proof, within, throws, BooleanOperators, secure, delay
 }
 import Gen.{
   const, fail, frequency, oneOf, choose, listOf, listOfN,
@@ -173,4 +173,10 @@ object PropSpecification extends Properties("Prop") {
       noneFailing(gs) || gs.exists(!_.sample.isDefined)
     }
   }
+
+  property("secure") = forAll { (prms: Parameters, e: Throwable) =>
+    secure(throw e).apply(prms).status == Exception(e)
+  }
+
+  property("delay") = { delay(???); proved }
 }


### PR DESCRIPTION
This addresses a problem I run into frequently with `Properties` being a mutable map.

``` scala
object Test extends Properties("foo") {
  property("bar") = secure {
    val c = connectToTheNetwork()
    val x = something(c)
    c.close()
    p(x)
  }
}
```

In the above, `connectToTheNetwork()` runs _at object creation time_ (!!!). This can cause all kinds of strange initialization errors and (more frequently) blocked threads. With this PR, you would instead say:

``` scala
object Test extends Properties("foo") {
  property("bar") = protect {
    val c = connectToTheNetwork
    val x = something(c)
    c.close()
    p(x)
  }
}
```

and nothing runs at object creation time, other than the creation of the `Prop` which is completely lazy.