### PR TITLE
Run the tests of the JS platform using Node.js instead of Rhino.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION $PLATFORM/clean $PLATFORM/update $PLATFORM/compile "$PLATFORM/testOnly * -- -s $TESTS -w $WORKERS" $PLATFORM/mimaReportBinaryIssues
+  - sbt ++$TRAVIS_SCALA_VERSION "set scalaJSStage in Global := FastOptStage" $PLATFORM/clean $PLATFORM/update $PLATFORM/compile "$PLATFORM/testOnly * -- -s $TESTS -w $WORKERS" $PLATFORM/mimaReportBinaryIssues
 env:
   - PLATFORM=jvm TESTS=1000 WORKERS=1
   - PLATFORM=jvm TESTS=1000 WORKERS=4

--- a/build.sbt
+++ b/build.sbt
@@ -56,9 +56,7 @@ lazy val sharedSettings = MimaSettings.settings ++ Seq(
 lazy val js = project.in(file("js"))
   .settings(sharedSettings: _*)
   .settings(
-    libraryDependencies += "org.scala-js" %% "scalajs-test-interface" % scalaJSVersion,
-    // Unfortunately, so far not everything links, although every runs fine
-    scalaJSOptimizerOptions ~= { _.withBypassLinkingErrors(true) }
+    libraryDependencies += "org.scala-js" %% "scalajs-test-interface" % scalaJSVersion
   )
   .enablePlugins(ScalaJSPlugin)
 

--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,9 @@ lazy val sharedSettings = MimaSettings.settings ++ Seq(
 lazy val js = project.in(file("js"))
   .settings(sharedSettings: _*)
   .settings(
-    libraryDependencies += "org.scala-js" %% "scalajs-test-interface" % scalaJSVersion
+    libraryDependencies += "org.scala-js" %% "scalajs-test-interface" % scalaJSVersion,
+    // Unfortunately, so far not everything links, although every runs fine
+    scalaJSOptimizerOptions ~= { _.withBypassLinkingErrors(true) }
   )
   .enablePlugins(ScalaJSPlugin)
 

--- a/js/src/main/scala/org/scalacheck/Platform.scala
+++ b/js/src/main/scala/org/scalacheck/Platform.scala
@@ -1,0 +1,24 @@
+/*-------------------------------------------------------------------------*\
+**  ScalaCheck                                                             **
+**  Copyright (c) 2007-2015 Rickard Nilsson. All rights reserved.          **
+**  http://www.scalacheck.org                                              **
+**                                                                         **
+**  This software is released under the terms of the Revised BSD License.  **
+**  There is NO WARRANTY. See the file LICENSE for the full text.          **
+\*------------------------------------------------------------------------ */
+
+package org.scalacheck
+
+import Test._
+
+private[scalacheck] object Platform {
+
+  def runWorkers(
+    params: Parameters,
+    workerFun: Int => Result,
+    stop: () => Unit
+  ): Result = {
+    workerFun(0)
+  }
+
+}

--- a/jvm/src/main/scala/org/scalacheck/Platform.scala
+++ b/jvm/src/main/scala/org/scalacheck/Platform.scala
@@ -1,0 +1,62 @@
+/*-------------------------------------------------------------------------*\
+**  ScalaCheck                                                             **
+**  Copyright (c) 2007-2015 Rickard Nilsson. All rights reserved.          **
+**  http://www.scalacheck.org                                              **
+**                                                                         **
+**  This software is released under the terms of the Revised BSD License.  **
+**  There is NO WARRANTY. See the file LICENSE for the full text.          **
+\*------------------------------------------------------------------------ */
+
+package org.scalacheck
+
+import Test._
+
+private[scalacheck] object Platform {
+
+  import util.FreqMap
+
+  def runWorkers(
+    params: Parameters,
+    workerFun: Int => Result,
+    stop: () => Unit
+  ): Result = {
+    import params._
+
+    def mergeResults(r1: Result, r2: Result): Result = {
+      val Result(st1, s1, d1, fm1, _) = r1
+      val Result(st2, s2, d2, fm2, _) = r2
+      if (st1 != Passed && st1 != Exhausted)
+        Result(st1, s1+s2, d1+d2, fm1++fm2, 0)
+      else if (st2 != Passed && st2 != Exhausted)
+        Result(st2, s1+s2, d1+d2, fm1++fm2, 0)
+      else {
+        if (s1+s2 >= minSuccessfulTests && maxDiscardRatio*(s1+s2) >= (d1+d2))
+          Result(Passed, s1+s2, d1+d2, fm1++fm2, 0)
+        else
+          Result(Exhausted, s1+s2, d1+d2, fm1++fm2, 0)
+      }
+    }
+
+    if(workers < 2) workerFun(0)
+    else {
+      import concurrent._
+      val tp = java.util.concurrent.Executors.newFixedThreadPool(workers)
+      implicit val ec = ExecutionContext.fromExecutor(tp)
+      try {
+        val fs = List.range(0,workers) map (idx => Future {
+          params.customClassLoader.map(
+            Thread.currentThread.setContextClassLoader(_)
+          )
+          blocking { workerFun(idx) }
+        })
+        val zeroRes = Result(Passed,0,0,FreqMap.empty[Set[Any]],0)
+        val res = Future.fold(fs)(zeroRes)(mergeResults)
+        Await.result(res, concurrent.duration.Duration.Inf)
+      } finally {
+        stop()
+        tp.shutdown()
+      }
+    }
+  }
+
+}

--- a/src/main/scala/org/scalacheck/Test.scala
+++ b/src/main/scala/org/scalacheck/Test.scala
@@ -345,45 +345,8 @@ object Test {
       } else res
     }
 
-    def mergeResults(r1: Result, r2: Result): Result = {
-      val Result(st1, s1, d1, fm1, _) = r1
-      val Result(st2, s2, d2, fm2, _) = r2
-      if (st1 != Passed && st1 != Exhausted)
-        Result(st1, s1+s2, d1+d2, fm1++fm2, 0)
-      else if (st2 != Passed && st2 != Exhausted)
-        Result(st2, s1+s2, d1+d2, fm1++fm2, 0)
-      else {
-        if (s1+s2 >= minSuccessfulTests && maxDiscardRatio*(s1+s2) >= (d1+d2))
-          Result(Passed, s1+s2, d1+d2, fm1++fm2, 0)
-        else
-          Result(Exhausted, s1+s2, d1+d2, fm1++fm2, 0)
-      }
-    }
-
     val start = System.currentTimeMillis
-
-    val r =
-      if(workers < 2) workerFun(0)
-      else {
-        import concurrent._
-        val tp = java.util.concurrent.Executors.newFixedThreadPool(workers)
-        implicit val ec = ExecutionContext.fromExecutor(tp)
-        try {
-          val fs = List.range(0,workers) map (idx => Future {
-            params.customClassLoader.map(
-              Thread.currentThread.setContextClassLoader(_)
-            )
-            blocking { workerFun(idx) }
-          })
-          val zeroRes = Result(Passed,0,0,FreqMap.empty[Set[Any]],0)
-          val res = Future.fold(fs)(zeroRes)(mergeResults)
-          Await.result(res, concurrent.duration.Duration.Inf)
-        } finally {
-          stop = true
-          tp.shutdown()
-        }
-      }
-
+    val r = Platform.runWorkers(params, workerFun, () => stop = true)
     val timedRes = r.copy(time = System.currentTimeMillis-start)
     params.testCallback.onTestResult("", timedRes)
     timedRes


### PR DESCRIPTION
This fixes the Travis builds, because Node.js is just so much faster and less memory-hungry.

After this PR, you may even want to consider bumping up the number of TESTS to be run in the JS env to something like 100 instead of just 20, because it's so much faster now.