### PR TITLE
add colors to console output

### DIFF
--- a/src/main/scala/org/scalacheck/ScalaCheckFramework.scala
+++ b/src/main/scala/org/scalacheck/ScalaCheckFramework.scala
@@ -126,7 +126,7 @@ private abstract class ScalaCheckRunner(
           val logMsg = s"$s $n: ${pretty(result, Params(verbosity))}"
           loggers.foreach(l =>
             if(l.ansiCodesSupported) 
-              l.info((if(result.passed) Console.GREEN else Console.RED) + logMsg + Console.RESET)
+              l.info((if (result.passed) Console.GREEN else Console.RED) + logMsg + Console.RESET)
             else
               l.info(logMsg))
         }

--- a/src/main/scala/org/scalacheck/ScalaCheckFramework.scala
+++ b/src/main/scala/org/scalacheck/ScalaCheckFramework.scala
@@ -124,7 +124,11 @@ private abstract class ScalaCheckRunner(
           val s = if (result.passed) "+" else "!"
           val n = if (name.isEmpty) taskDef.fullyQualifiedName else name
           val logMsg = s"$s $n: ${pretty(result, Params(verbosity))}"
-          loggers.foreach(l => l.info(logMsg))
+          loggers.foreach(l =>
+            if(l.ansiCodesSupported) 
+              l.info((if(result.passed) Console.GREEN else Console.RED) + logMsg + Console.RESET)
+            else
+              l.info(logMsg))
         }
 
         Array.empty[Task]


### PR DESCRIPTION
This adds green/red coloring to log output (where supported), making visual test inspection much simpler.