### PR TITLE
Use Travis Build Containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,4 @@ matrix:
     - scala: 2.12.0-M1
       jdk: openjdk7
       env: PLATFORM=jvm SBT_PARALLEL=true WORKERS=4 DEPLOY=true
+sudo: false


### PR DESCRIPTION
Some of the scalacheck tests fail with code 137, which usually indicates they're running up against Travis' resource limits. The [new Travis infrastructure] (http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade) provides "...2 dedicated cores and 4GB of memory, vs 1.5 cores and 3GB...", which should alleviate the issue.