### PR TITLE
prevent NPE with Gen.oneOf (#177)

### DIFF
--- a/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
@@ -12,7 +12,7 @@ package org.scalacheck
 import rng.Seed
 
 import Gen._
-import Prop.{forAll, someFailing, noneFailing, sizedProp}
+import Prop.{forAll, someFailing, noneFailing, sizedProp, secure}
 import Arbitrary._
 import Shrink._
 import java.util.Date
@@ -266,4 +266,9 @@ object GenSpecification extends Properties("Gen") {
   property("random (Boolean => Trilean) functions") = exhaust(N, tf, utf)
   property("random (Trilean => Boolean) functions") = exhaust(N, utf, tf)
   property("random (Trilean => Trilean) functions") = exhaust(N, utf, utf)
+
+  property("oneOf with Buildable supports null in first or 2nd position") = secure {
+    Gen.oneOf(Gen.const(null), Arbitrary.arbitrary[Array[Byte]]).sample.isDefined &&
+    Gen.oneOf(Arbitrary.arbitrary[Array[Byte]], Gen.const(null)).sample.isDefined
+  }
 }

--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -439,8 +439,9 @@ object Gen extends GenArities{
   def buildableOf[C,T](g: Gen[T])(implicit
     evb: Buildable[T,C], evt: C => Traversable[T]
   ): Gen[C] =
-    sized(s => choose(0,s).flatMap(buildableOfN[C,T](_,g))) suchThat { c =>
-      c.forall(g.sieveCopy)
+    sized(s => choose(0,s).flatMap(buildableOfN[C,T](_,g))) suchThat {
+      case c@null => g.sieveCopy(c)
+      case c => c.forall(g.sieveCopy)
     }
 
   /** Generates a non-empty container of any Traversable type for which there


### PR DESCRIPTION
This fixes #177 , but I wasn't able to figure out why the position of `Gen.const(null)` has an impact. One thing I noticed is that in the  `Gen.oneOf(Gen.const(null), ....)` case, the sized `Gen` created in `buildableOf` never evaluates `suchThat` with the null value. However, this obviously does occur if the null const is not the first argument. 

Hopefully someone more familiar with the codebase can suggest what the underlying issue is. In the meantime, this patch addresses the simple issue described in the above ticket.