### PR TITLE
Allow overriding of Test.Parameters in Properties

### DIFF
--- a/src/main/scala/org/scalacheck/Properties.scala
+++ b/src/main/scala/org/scalacheck/Properties.scala
@@ -32,6 +32,12 @@ class Properties(val name: String) {
 
   private val props = new scala.collection.mutable.ListBuffer[(String,Prop)]
 
+  /**
+   * Changes to the test parameters that are specific to this class.
+   * Can be used to set custom parameter values for this test.
+   */
+  def overrideParameters(p: Test.Parameters): Test.Parameters = p
+
   /** Returns all properties of this collection in a list of name/property
    *  pairs.  */
   def properties: Seq[(String,Prop)] = props
@@ -44,9 +50,12 @@ class Properties(val name: String) {
    *  If you need to get the results
    *  from the test use the `check` methods in [[org.scalacheck.Test]]
    *  instead. */
-  def check(prms: Test.Parameters = Test.Parameters.default): Unit = Test.checkProperties(
-    prms.withTestCallback(ConsoleReporter(1) chain prms.testCallback), this
-  )
+  def check(prms: Test.Parameters = Test.Parameters.default): Unit = {
+    val params = overrideParameters(prms)
+    Test.checkProperties(
+      params.withTestCallback(ConsoleReporter(1) chain params.testCallback), this
+    )
+  }
 
   /** Convenience method that makes it possible to use this property collection
    *  as an application that checks itself on execution. Calls `System.exit`

--- a/src/main/scala/org/scalacheck/Test.scala
+++ b/src/main/scala/org/scalacheck/Test.scala
@@ -327,15 +327,17 @@ object Test {
   }
 
   /** Check a set of properties. */
-  def checkProperties(prms: Parameters, ps: Properties): Seq[(String,Result)] =
+  def checkProperties(prms: Parameters, ps: Properties): Seq[(String,Result)] = {
+    val params = ps.overrideParameters(prms)
     ps.properties.map { case (name,p) =>
       val testCallback = new TestCallback {
         override def onPropEval(n: String, t: Int, s: Int, d: Int) =
-          prms.testCallback.onPropEval(name,t,s,d)
+          params.testCallback.onPropEval(name,t,s,d)
         override def onTestResult(n: String, r: Result) =
-          prms.testCallback.onTestResult(name,r)
+          params.testCallback.onTestResult(name,r)
       }
-      val res = check(prms.withTestCallback(testCallback), p)
+      val res = check(params.withTestCallback(testCallback), p)
       (name,res)
     }
+  }
 }


### PR DESCRIPTION
This is a basic implementation of the feature request in #187.
This would allow a user to do something like 

```scala
object MyProperties extends Properties("My object") {
  override def overrideParams(p: Test.Parameters) = p.withMinSuccessfulTests(20)
}
```
if they want Scalacheck to, for this class only, run 20 tests per property instead of whatever value was specified in the sbt argument or the project default.