### PR TITLE
Add Gen.some for converting generators to Some(T)

### DIFF
--- a/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
@@ -199,6 +199,13 @@ object GenSpecification extends Properties("Gen") {
     }
   }
 
+  property("some") = forAll { n: Int =>
+    forAll(some(n)) {
+      case Some(m) if m == n => true
+      case _ => false
+    }
+  }
+
   property("uuid version 4") = forAll(uuid) { _.version == 4 }
 
   property("uuid unique") = forAll(uuid, uuid) {

--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -384,7 +384,11 @@ object Gen extends GenArities{
 
   /** Makes a generator result optional. Either `Some(T)` or `None` will be provided. */
   def option[T](g: Gen[T]): Gen[Option[T]] =
-    oneOf[Option[T]](g.map(Some.apply), None)
+    oneOf[Option[T]](some(g), None)
+
+  /** A generator that returns `Some(T)` */
+  def some[T](g: Gen[T]): Gen[Option[T]] =
+    g.map(Some.apply)
 
   /** Chooses one of the given generators with a weighted random distribution */
   def frequency[T](gs: (Int,Gen[T])*): Gen[T] = {


### PR DESCRIPTION
`Gen.some(g)` is not that much shorter than `g.map(Some.apply)`, but it's a nice parallel to `Gen.option`. Presently we have defined `some` as a convenience function that we use extensively in our scalacheck tests at Twitter.