### PR TITLE
Fix typo in Commands

### DIFF
--- a/src/main/scala/org/scalacheck/commands/Commands.scala
+++ b/src/main/scala/org/scalacheck/commands/Commands.scala
@@ -14,7 +14,7 @@ import scala.util.{Try, Success, Failure}
 
 /** An API for stateful testing in ScalaCheck.
  *
- *  For an implemtation overview, see the examples in ScalaCheck's source tree.
+ *  For an implementation overview, see the examples in ScalaCheck's source tree.
  *
  *  @since 1.12.0
  */


### PR DESCRIPTION
Found a small typo: 

```
For an implemtation overview
```