### PR TITLE
Add the possibility to shrink the state in commands

### DIFF
--- a/jvm/src/test/scala/org/scalacheck/commands/CommandsSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/commands/CommandsSpecification.scala
@@ -28,6 +28,8 @@ object CommandsSpecification extends Properties("Commands") {
     type Sut = Counter
     type State = Int
 
+    override def shrinkState: Shrink[Int] = implicitly
+
     def canCreateNewSut(newState: State, initSuts: Traversable[State],
       runningSuts: Traversable[Sut]) = true
 


### PR DESCRIPTION
Adds a `shrinkState` method to the `Commands` trait to allow shrinking of the `State` inside imperative specifications.  I added an override in the `CommandsSpecification` file for the counter example.

Some notes you might want to take into account:

- unfortunately, [this](https://github.com/rickynils/scalacheck/compare/master...markus1189:shrink-state?expand=1#diff-f58118b457fead9d506c771626fa3d5fR233) always resolves to the `anyInstance` for Shrink, which does no shrinking at all, which means you *always* have to overwrite the `shrinkState` method, even if your internal `State` is only `Int` instead of a custom type.  I think we should consider to add this to the user guide somehow.  I would be happy to do this if wanted.

- [here](https://github.com/rickynils/scalacheck/compare/master...markus1189:shrink-state?expand=1#diff-f58118b457fead9d506c771626fa3d5fR252)  I decided to first check for `Actions` that are shrinked for all fields (`state`,`seqCmds`,`parCmds`), is this a sensible order?  I am not sure what the smartest shrinking order is ;)