### PR TITLE
Allow Gen.choose to handle a very large range of doubles

### DIFF
--- a/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
@@ -85,8 +85,11 @@ object GenSpecification extends Properties("Gen") {
   }
 
   property("choose-double") = forAll { (l: Double, h: Double) =>
-    if(l > h || h-l > Double.MaxValue) choose(l,h) == fail
-    else forAll(choose(l,h)) { x => x >= l && x <= h }
+    forAll(choose(l,h)) { x => x >= l && x <= h }
+  }
+
+  property("choose-large-double") = forAll(choose(Double.MinValue, Double.MaxValue)) { x =>
+    x >= Double.MinValue && x <= Double.MaxValue
   }
 
   property("choose-xmap") = {

--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -26,7 +26,7 @@ sealed abstract class Gen[+T] {
   private type P = Gen.Parameters
 
   /** Should be a copy of R.sieve. Used internally in Gen when some generators
-   *  with suchThat-claues are created (when R is not available). This method
+   *  with suchThat-clause are created (when R is not available). This method
    *  actually breaks covariance, but since this method will only ever be
    *  called with a value of exactly type T, it is OK. */
   private[scalacheck] def sieveCopy(x: Any): Boolean = true
@@ -261,7 +261,8 @@ object Gen extends GenArities{
 
     private def chDbl(l: Double, h: Double)(p: P, seed: Seed): R[Double] = {
       val d = h-l
-      if (d < 0 || d > Double.MaxValue) r(None, seed)
+      if (d < 0) r(None, seed)
+      else if (d > Double.MaxValue) r(oneOf(choose(l, 0d), choose(0d, h)).apply(p, seed), seed.next)
       else if (d == 0) r(Some(l), seed)
       else {
         val (n, s) = seed.double


### PR DESCRIPTION
A proposed fix for issue #186.

When generating a random double in a range, `chDbl` is calculating max-min, which could potentially be outside of the range of doubles. To prevent this, `chDbl` is just discarding those values, which causes ranges like `Gen.choose(Double.MinValue, Double.MaxValue)` to fail.

As issue #186 says, you're probably better off using `Arbitrary` in this case (they use different generation strategies, and the distribution of doubles produced by `Arbitrary` is probably more useful), but I think it's reasonable to expect `Gen.choose(Double.MinValue, Double.MaxValue)` to generate something.

I've fixed the issue by copying the strategy used in [drmaciver/hypothesis](https://github.com/DRMacIver/hypothesis) for [float generation](https://github.com/DRMacIver/hypothesis/blob/master/src/hypothesis/strategies.py): if max-min is out of the double range, then recursively call the double generator with a range of _either_ min to zero, or zero to max.