### PR TITLE
Added symbolic/dynamic terms to ScalaCheck.Commands

### DIFF
--- a/jvm/src/test/scala/org/scalacheck/commands/CommandsSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/commands/CommandsSpecification.scala
@@ -46,24 +46,24 @@ object CommandsSpecification extends Properties("Commands") {
 
     case object Get extends SuccessCommand {
       type Result = Int
-      def run(sut: Sut) = sut.get
-      def nextState(state: State) = state
+      def run(sut: Sut, state: State) = sut.get
+      def nextState(state: State, v:Term[Result]) = state
       def preCondition(state: State) = true
       def postCondition(state: State, result: Result) = result == state
     }
 
     case object Inc extends SuccessCommand {
       type Result = Int
-      def run(sut: Sut) = sut.inc
-      def nextState(state: State) = state+1
+      def run(sut: Sut, state: State) = sut.inc
+      def nextState(state: State, v:Term[Result]) = state+1
       def preCondition(state: State) = true
       def postCondition(state: State, result: Result) = result == (state+1)
     }
 
     case object Dec extends SuccessCommand {
       type Result = Int
-      def run(sut: Sut) = sut.dec
-      def nextState(state: State) = state-1
+      def run(sut: Sut, state: State) = sut.dec
+      def nextState(state: State, v:Term[Result]) = state-1
       def preCondition(state: State) = true
       def postCondition(state: State, result: Result) = result == (state-1)
     }

--- a/jvm/src/test/scala/org/scalacheck/commands/MultiPidSpawnerSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/commands/MultiPidSpawnerSpecification.scala
@@ -1,0 +1,218 @@
+package org.scalacheck.commands
+
+import scala.util.Random
+import org.scalacheck._
+import org.scalacheck.commands._
+import org.scalacheck.Gen._
+import scala.util.{Success, Failure, Try}
+import java.io.PrintWriter
+import java.io.File
+
+class MultiPidSpawner() {
+  case class MultiPidSpawnerState(
+    pids: Seq[String],
+    regs: Map[String, String])
+
+  private val uuids:Seq[String] =  Seq.fill(Random.nextInt(20))(genUUID())
+    
+  var state = MultiPidSpawnerState(pids = uuids, regs = Map.empty)
+
+  def genUUID() = java.util.UUID.randomUUID.toString
+
+  def listPids(): Seq[String] = state.pids
+
+  def register(uuid: String, name: String): Unit = {
+    if(state.pids.exists(x => x == uuid)) {
+      if(!state.regs.exists(x => x._1 == name || x._2 == uuid)) {
+        state = state.copy(regs = state.regs ++ Map(name -> uuid))
+      } else {
+        throw new Exception("Cannot register a UUID twice.")
+      }
+    } else {
+      throw new Exception("No PIDs!")
+    }
+  }
+
+  def unregister(name: String): Unit = {
+    state.regs.find(_._1 == name) map {
+      case _ => {
+        state = state.copy(regs = state.regs - name)
+      }
+    } getOrElse (throw new Exception("No such registration as " + name))
+  }
+
+  def whereis(name: String): Option[String] = {
+    state.regs.find(_._1 == name).map { case (n,u) => u }
+  }
+}
+
+object CommandsMultiPidRegistration extends Properties("CommandsMultiPidRegistration") {
+  property("multipidregspec") = MultiPidRegistrationSpecification.property(threadCount = 1)
+}
+
+object MultiPidRegistrationSpecification extends Commands {
+
+  type Sut = MultiPidSpawner
+
+  case class State(
+    pids: Option[Term[Seq[String]]],
+    regs: Map[String, Int])
+
+  override def genInitialState: Gen[State] = State(pids = None, regs = Map.empty)
+
+  override def canCreateNewSut(newState: State, initSuts: Traversable[State],
+                               runningSuts: Traversable[Sut]
+                                ): Boolean = {
+    initSuts.isEmpty && runningSuts.isEmpty
+  }
+
+  override def destroySut(sut: Sut): Unit = {
+  }
+
+  override def initialPreCondition(state: State): Boolean = true
+
+  override def newSut(state: State): Sut = {
+    new MultiPidSpawner()
+  }
+  
+  def genCommand(state: State): Gen[Command] = {
+    frequency(
+      (50, genListPids),
+      (20, genRegisterIdx(state)),
+      (20, genUnregister(state)),
+      (5, genWhereIsRandom),
+      (20, genWhereIs(state)),
+      (5, genUnregisterRandom),
+      (20, genUnregister(state))
+    )
+  }
+
+  def genListPids: Gen[ListPids] = ListPids()
+  
+  def genRegisterIdx(state: State) = {
+    if(state.pids.isEmpty) genListPids else for {
+      idx <- Gen.chooseNum(0,20)
+      name <- Gen.identifier
+    } yield RegisterIdx(idx, name)
+  }
+
+  def genUnregisterRandom = {
+    for {
+      id <- identifier
+    } yield Unregister(id)
+  }
+
+  def genUnregister(state: State) = {
+    if(state.regs.isEmpty) genUnregisterRandom else for {
+      (name,_) <- oneOf(state.regs.toSeq)
+    } yield Unregister(name)
+  }
+
+  def genWhereIsRandom = {
+    for {
+      id <- Gen.identifier
+    } yield WhereIs(id)
+  }
+
+  def genWhereIs(state: State) = {
+    if(state.regs.isEmpty) genWhereIsRandom else for {
+      (id,_) <- oneOf(state.regs.toSeq)
+    } yield WhereIs(id)
+  }
+  
+  case class ListPids() extends Command {
+    override type Result = Seq[String]
+
+    override def preCondition(s: State): Boolean = true
+
+    override def nextState(s: State, v:Term[Result]) = {
+      s.copy(pids = Option(v))
+    }
+
+    override def postCondition(s: State, result: Try[Result]): Prop = {
+      result.isSuccess
+    }
+
+    override def run(sut: Sut, s: State): Result = {
+      sut.listPids()
+    }
+  }
+
+  // RegisterIdx is constructed with a random index, which may or may not
+  // turn out to be valid. Fortunately, at runtime we will know whether
+  // it is valid or not, and can react accordingly.
+  case class RegisterIdx(pidIdx: Int, name: String) extends Command {
+    override type Result = Unit
+    
+    override def preCondition(state: State) = state.pids.isDefined
+    
+    override def run(sut: Sut, s: State): Result = {
+      val pids = s.pids.valueOrElse(Seq())
+      val pid  = pids.lift(pidIdx) getOrElse "Invalid PID"
+      sut.register(pid, name)
+    }
+    
+    // Success is expected if there was no registration, and the list index is valid.
+    override def postCondition(s: State, result: Try[Result]): Prop = {
+      val pids  = s.pids.valueOrElse(Seq())
+      if(!s.regs.exists(r => r._1 == name || r._2 == pidIdx) && pids.isDefinedAt(pidIdx)) {
+        result.isSuccess
+      } else {
+        result.isFailure
+      }
+    }
+    
+    override def nextState(s: State, v:Term[Result]) = {
+      if(s.regs.exists(r => r._1 == name || r._2 == pidIdx)) {
+        s
+      } else {
+        s.copy(regs = s.regs ++ Map(name -> pidIdx))
+      }
+    }
+  }
+
+  case class WhereIs(name: String) extends Command {
+    override type Result = Option[String]
+
+    override def preCondition(s: State): Boolean = s.pids.isDefined
+
+    override def nextState(s: State, v:Term[Result]) = s
+    
+    override def postCondition(s: State, result: Try[Result]): Prop = {
+      val uuid1 = result map { case v => v } getOrElse (None)
+      
+      val uuid2 = s.regs.find(_._1 == name) flatMap { case (_, idx) =>
+          val pids = s.pids.valueOrElse(Seq())
+          pids.lift(idx)
+      }
+      
+      uuid1 == uuid2
+    }
+
+    override def run(sut: Sut, s: State): Result = {
+      sut.whereis(name)
+    }
+  }
+
+  case class Unregister(name: String) extends Command {
+    override type Result = Unit
+
+    override def preCondition(state: State): Boolean = true
+
+    override def nextState(s: State, v:Term[Result]) = {
+      if(s.regs.contains(name)) s.copy(regs = s.regs - name)
+      else s
+    }
+
+    override def postCondition(s: State, result: Try[Result]): Prop = {
+      s.regs.find(_._1 == name) map { case (_, idx) =>
+          val pids = s.pids.valueOrElse(Seq())
+          pids.lift(idx) map ( _ => result.isSuccess ) getOrElse result.isFailure
+      } getOrElse[Boolean] result.isFailure
+    }
+
+    override def run(sut: Sut, s: State): Result = {
+      sut.unregister(name)
+    }
+  }
+}

--- a/jvm/src/test/scala/org/scalacheck/commands/MultiPidSpawnerSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/commands/MultiPidSpawnerSpecification.scala
@@ -205,10 +205,14 @@ object MultiPidRegistrationSpecification extends Commands {
     }
 
     override def postCondition(s: State, result: Try[Result]): Prop = {
-      s.regs.find(_._1 == name) map { case (_, idx) =>
+      val reg = s.regs.find(_._1 == name) flatMap { case (_, idx) =>
           val pids = s.pids.valueOrElse(Seq())
-          pids.lift(idx) map ( _ => result.isSuccess ) getOrElse result.isFailure
-      } getOrElse[Boolean] result.isFailure
+          pids.lift(idx)// map ( _ => result.isSuccess ) getOrElse result.isFailure
+      }
+      reg match {
+        case None => result.isFailure
+        case Some(x) => result.isSuccess
+      }
     }
 
     override def run(sut: Sut, s: State): Result = {

--- a/jvm/src/test/scala/org/scalacheck/commands/MultiPidSpawnerSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/commands/MultiPidSpawnerSpecification.scala
@@ -143,31 +143,12 @@ object MultiPidRegistrationSpecification extends Commands {
     override type Result = Unit
     override def preCondition(state: State) = state.pids.isDefined
     override def run(sut: Sut, s: State): Result = {
-      // Option 0: Map Option into Term into Seq[String] 
       {
         for {
           pids <- s.pids.flatMap(_.map(identity))
           pid <- pids.lift(pidIdx)
         } yield sut.register(pid, name)
       } getOrElse sut.register("Invalid pid", name)
-      /*
-      // Option 1: Bind term, then getOrElse term value.
-      {
-        for {
-          pids <- s.pids
-          pid <- pids.getOrElse(Seq()).lift(pidIdx)
-        } yield sut.register(pid, name)
-      } getOrElse sut.register("Invalid pid", name)
-      
-      // Option 2: Bind term, then bind term value.
-      {
-        for {
-          term <- s.pids
-          pids <- term
-          pid <- pids.lift(pidIdx)
-        } yield sut.register(pid, name)
-      } getOrElse sut.register("Invalid pid", name)
-      */
     }
     
     // Success is expected if: There are pids, the registration isn't taken and the index is valid.

--- a/jvm/src/test/scala/org/scalacheck/commands/MultiPidSpawnerSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/commands/MultiPidSpawnerSpecification.scala
@@ -153,8 +153,7 @@ object MultiPidRegistrationSpecification extends Commands {
     
     // Success is expected if: There are pids, the registration isn't taken and the index is valid.
     override def postCondition(s: State, result: Try[Result]): Prop = {
-     {
-        for {
+     val ok = for {
           term <- s.pids
           pids <- term
         } yield {
@@ -164,7 +163,10 @@ object MultiPidRegistrationSpecification extends Commands {
             result.isSuccess
           }
         }
-      } getOrElse[Boolean] false
+      ok match {
+        case Some(v) => v
+        case None => false
+      }
     }
     
     override def nextState(s: State, v:Term[Result]) = {
@@ -214,10 +216,14 @@ object MultiPidRegistrationSpecification extends Commands {
     }
 
     override def postCondition(s: State, result: Try[Result]): Prop = {
-      s.regs.find(_._1 == name) map { case (_, idx) =>
+      var ok = s.regs.find(_._1 == name) map { case (_, idx) =>
         val pids = s.pids.flatMap(_.map(identity)) getOrElse(Seq())
         pids.lift(idx) map ( _ => result.isSuccess ) getOrElse result.isFailure
-      } getOrElse[Boolean] result.isFailure
+      }
+      ok match {
+        case Some(v) => v
+        case None => result.isFailure
+      }
       
     }
 

--- a/jvm/src/test/scala/org/scalacheck/commands/PidSpawnerSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/commands/PidSpawnerSpecification.scala
@@ -174,17 +174,11 @@ object PidRegistrationSpecification extends Commands{
 
     override def nextState(s: State, v:Term[Result]) = s
 
-    // If there is a registration for name, we expect to get a UUID back equal to it.
-    // If there is not, we expect to get no UUID back.
     override def postCondition(s: State, result: Try[Result]): Prop = {
-      // TODO:
-      result map { opt =>  
-        s.regs.get(name) match {
-          case Some(DynVar(_,Success(v))) if Option(v) == opt => true
-          case None => opt.isEmpty
-          case _ => false
-        }
-      } getOrElse[Boolean] false
+      result match {
+        case Success(opt) => opt == s.regs.find(_._1 == name).map(_._2).valueOpt
+        case Failure(e) => Prop.exception(e)
+      }
     }
 
     override def run(sut: Sut, s: State): Result = {
@@ -204,7 +198,6 @@ object PidRegistrationSpecification extends Commands{
       else s
     }
 
-    // We expect true only if there was a registration with that name.
     override def postCondition(s: State, result: Try[Result]): Prop = {
       if(result.isSuccess) prep(s)
       else !prep(s)

--- a/jvm/src/test/scala/org/scalacheck/commands/PidSpawnerSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/commands/PidSpawnerSpecification.scala
@@ -162,8 +162,10 @@ object PidRegistrationSpecification extends Commands{
     }
     
     override def run(sut: Sut, s: State): Result = {
-      val pid = findPid(s).valueOrElse("Invalid PID")
-      sut.register(pid, name)
+      for {
+        term <- s.pids.find(_.binding == bind)
+        pid <- term
+      } yield sut.register(pid, name)
     }
   }
 
@@ -176,7 +178,7 @@ object PidRegistrationSpecification extends Commands{
 
     override def postCondition(s: State, result: Try[Result]): Prop = {
       result match {
-        case Success(opt) => opt == s.regs.find(_._1 == name).map(_._2).valueOpt
+        case Success(opt) => opt == s.regs.get(name).flatMap(_.map(identity))
         case Failure(e) => Prop.exception(e)
       }
     }

--- a/jvm/src/test/scala/org/scalacheck/commands/PidSpawnerSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/commands/PidSpawnerSpecification.scala
@@ -1,0 +1,217 @@
+package org.scalacheck.commands
+
+import org.scalacheck._
+import org.scalacheck.commands._
+import org.scalacheck.Gen._
+import scala.util.{Success, Failure, Try}
+import java.nio.file.{Paths, Files}
+import java.nio.charset.StandardCharsets
+import java.io.PrintWriter
+import java.io.File
+import org.scalacheck.Properties
+
+class PidSpawner() {
+  case class PidSpawnerState(
+    pids: Set[String],
+    regs: Map[String, String])
+
+  var state = PidSpawnerState(pids = Set.empty, regs = Map.empty)
+
+  def genUUID() = java.util.UUID.randomUUID.toString
+
+  def spawn():String = {
+    val uuid = genUUID()
+    state = state.copy(pids = state.pids + uuid)
+    uuid
+  }
+
+  def register(uuid: String, name: String): Unit = {
+    if(state.pids.exists(x => x == uuid) && !state.regs.exists(x => x._1 == name)) {
+      state = state.copy(regs = state.regs ++ Map(name -> uuid))
+    } else {
+      throw new Exception(s"Unable to register ${name} -> ${uuid}.")
+    }
+  }
+
+  def unregister(name: String): Unit = {
+    if(state.regs.contains(name)) {
+      state = state.copy(regs = state.regs - name)
+    } else {
+      throw new Exception(s"Unable to unregister ${name}")
+    }
+  }
+
+  def whereis(name: String): Option[String] = {
+    state.regs.find(_._1 == name).map { case (n,u) => u }
+  }
+}
+
+object CommandsPidRegistration extends Properties("CommandsPidRegistration") {
+  import org.scalacheck.Test._
+  
+  property("pidregspec") = PidRegistrationSpecification.property()
+}
+
+object PidRegistrationSpecification extends Commands{
+  
+  type Sut = PidSpawner
+
+  case class State(
+    pids: Set[Term[String]],
+    regs: Map[String, Term[String]])
+
+  override def genInitialState: Gen[State] = State(
+    pids = Set.empty,
+    regs = Map.empty)
+
+
+  override def canCreateNewSut(newState: State, initSuts: Traversable[State],
+                               runningSuts: Traversable[Sut]
+                                ): Boolean = {
+    initSuts.isEmpty && runningSuts.isEmpty
+  }
+
+  override def destroySut(sut: Sut): Unit = {
+  }
+
+  override def initialPreCondition(state: State): Boolean = true
+
+  override def newSut(state: State): Sut = {
+    new PidSpawner()
+  }
+  
+  def genCommand(state: State): Gen[Command] = {
+    frequency(
+      (50, genSpawn),
+      (20, genRegister(state)),
+      (20, genUnregister(state)),
+      (5, genWhereIsRandom),
+      (20, genWhereIs(state)),
+      (5, genUnregisterRandom),
+      (20, genUnregister(state))
+    )
+  }
+
+  def genSpawn: Gen[Spawn] = Spawn()
+
+  def genRegister(state: State): Gen[Command] = {
+    if(state.pids.isEmpty) genSpawn else for {
+      SymbVar(binding) <- Gen.oneOf(state.pids.toSeq)
+      name <- Gen.identifier
+    } yield Register(binding, name)
+  }
+
+  def genUnregisterRandom: Gen[Command] = {
+    for {
+      id <- identifier
+    } yield Unregister(id)
+  }
+
+  def genUnregister(state: State): Gen[Command] = {
+    if(state.regs.isEmpty) genUnregisterRandom else for {
+      (name,_) <- oneOf(state.regs.toSeq)
+    } yield Unregister(name)
+  }
+
+  def genWhereIsRandom: Gen[Command] = {
+    for {
+      id <- Gen.identifier
+    } yield WhereIs(id)
+  }
+
+  def genWhereIs(state: State): Gen[Command] = {
+    if(state.regs.isEmpty) genWhereIsRandom else for {
+      (id,_) <- oneOf(state.regs.toSeq)
+    } yield WhereIs(id)
+  }
+
+  case class Spawn() extends Command {
+    
+    override type Result = String
+
+    override def preCondition(s: State): Boolean = true
+
+    override def nextState(s: State, v:Term[Result]) = {
+      s.copy(pids = s.pids + v)
+    }
+
+    override def postCondition(s: State, result: Try[Result]): Prop = {
+      result.isSuccess
+    }
+
+    override def run(sut: Sut, s: State): Result = {
+      sut.spawn()
+    }
+  }
+
+  case class Register(bind: Binding, name: String) extends Command {
+    def findPid(s: State) = s.pids.find(_.binding == bind)
+    override type Result = Unit
+    override def preCondition(state: State): Boolean = findPid(state).isDefined
+    override def nextState(s: State, v:Term[Result]) = {
+      if(s.regs.contains(name)) {
+        s
+      } else {
+        findPid(s) map { case t => s.copy(regs = s.regs ++ Map(name -> t)) } getOrElse(s)
+      }
+    }
+
+    override def postCondition(s: State, result: Try[Result]): Prop = {
+      if(!s.regs.contains(name)) result.isSuccess
+      else result.isFailure
+    }
+    
+    override def run(sut: Sut, s: State): Result = {
+      val pid = findPid(s).valueOrElse("Invalid PID")
+      sut.register(pid, name)
+    }
+  }
+
+  case class WhereIs(name: String) extends Command {
+    override type Result = Option[String]
+
+    override def preCondition(s: State): Boolean = true
+
+    override def nextState(s: State, v:Term[Result]) = s
+
+    // If there is a registration for name, we expect to get a UUID back equal to it.
+    // If there is not, we expect to get no UUID back.
+    override def postCondition(s: State, result: Try[Result]): Prop = {
+      // TODO:
+      result map { opt =>  
+        s.regs.get(name) match {
+          case Some(DynVar(_,Success(v))) if Option(v) == opt => true
+          case None => opt.isEmpty
+          case _ => false
+        }
+      } getOrElse[Boolean] false
+    }
+
+    override def run(sut: Sut, s: State): Result = {
+      sut.whereis(name)
+    }
+  }
+  
+  case class Unregister(name: String) extends Command {
+    override type Result = Unit
+
+    def prep(s: State) = s.regs.contains(name)
+    
+    override def preCondition(state: State): Boolean = true
+
+    override def nextState(s: State, v:Term[Result]) = {
+      if(prep(s)) s.copy(regs = s.regs - name)
+      else s
+    }
+
+    // We expect true only if there was a registration with that name.
+    override def postCondition(s: State, result: Try[Result]): Prop = {
+      if(result.isSuccess) prep(s)
+      else !prep(s)
+    }
+
+    override def run(sut: Sut, s: State): Result = {
+      sut.unregister(name)
+    }
+  }
+}

--- a/src/main/scala/org/scalacheck/commands/Commands.scala
+++ b/src/main/scala/org/scalacheck/commands/Commands.scala
@@ -11,6 +11,7 @@ package org.scalacheck.commands
 
 import org.scalacheck._
 import scala.util.{Try, Success, Failure}
+import scala.language.implicitConversions
 
 /** An API for stateful testing in ScalaCheck.
  *
@@ -19,7 +20,85 @@ import scala.util.{Try, Success, Failure}
  *  @since 1.12.0
  */
 trait Commands {
+/**
+    *  The [[Term]] type models a (per test) unique binding, and a possible
+    *  value. Symbolic terms are meant for use during test generation, and
+    *  dynamic terms are for runtime. ScalaCheck automatically encapsulates the
+    *  results of a command into SymbolicTerm's during test generation, and DynamicTerm's
+    *  during runtime.
+    */
+  sealed abstract class Term[A](val binding: Binding) {
+    def get: Try[A]
+    def isEmpty: Boolean
+    def isDefined: Boolean = !isEmpty
+    final def nonEmpty = isDefined
+    final def getOrElse[B >: A](default: => B): B = if (isEmpty || get.isFailure) default else this.get.get
+    final def orNull[A1 >: A](implicit ev: Null <:< A1): A1 = this getOrElse ev(null)
+    
+    // Returns result of applying $f to this $term's value if
+    // the term is non-empty and has a Success value. Otherwise,
+    // evaluates ifEmpty.
+    final def fold[B](ifEmpty: => B)(f: A => B): B = if(isEmpty) ifEmpty else f(get.get)
+    
+    final def map[B](f: A => B): Option[B] = {
+      if(isEmpty) None else Some(f(get.get))
+    }
+    
+    final def flatMap[B](f: A => Option[B]): Option[B] = {
+      if(isEmpty) None else f(get.get)
+    }
+    
+    // Will return Some(value), if there is a Success value and p is true. Otherwise None
+    final def filter(p: A => Boolean): Option[A] =
+      if(isEmpty) None else if(p(get.get)) Some(get.get) else None
+    
+    // Filters based on the binding, not the value.
+    final def filterBinding(p: Binding => Boolean): Option[Term[A]] =
+      if(p(this.binding)) Some(this) else None
+    
+    final def contains[A1 >: A](elem: A1): Boolean =
+      !isEmpty && get.get == elem
+    
+    final def exists(p: A => Boolean): Boolean =
+      !isEmpty && p(get.get)
+    
+    final def forall(p: A => Boolean): Boolean = isEmpty || p(get.get)
+    
+    final def foreach[U](f: A => U) {
+        if(!isEmpty) f(get.get)
+      }
+    
+    final def collect[B](pf: PartialFunction[A, B]): Option[B] =
+      if(!isEmpty) pf.lift(this.get.get) else None
+      
+    final def orElse[B >: A](alternative: => Option[B]): Option[B] =
+      if(isEmpty) alternative else Some(this.get.get)
+  }
+  
+   /**
+   * A Binding is a (per SUT) unique identifier, basically a wrapped int with a nicer name. This helps clarify
+   * intent, if you need to keep track of term bindings in your State, e.g. a Map[String, Binding]
+   * has the clear intent of mapping strings to a term binding, while Map[String, Int] is less clear.
+   */
+  case class Binding(val binding: Int)
+  implicit def intToBinding(o: Int) = new Binding(o)
+  
+  case class SymbVar[A](override val binding: Binding) extends Term[A](binding) {
+    override def isEmpty = true
+    override def get = throw new NoSuchElementException("SymbVar.get")
+  }
+  
+  case class DynVar[A](override val binding: Binding, val value: Try[A]) extends Term[A](binding) {
+    override def isEmpty = get.isFailure
+    override def get = value
+  }
 
+  class OptionTerm[A](opt: Option[Term[A]]) {
+    def valueOrElse[B >: A](a: B): B = valueOpt getOrElse a
+    def valueOpt: Option[A] = opt flatMap { term => term map { v => v } }
+  }
+
+  implicit def optionToTermOption[A](o: Option[Term[A]]) = new OptionTerm[A](o)
   /** The abstract state type. Must be immutable.
    *  The [[State]] type should model the state of the system under
    *  test (SUT). It should only contain details needed for specifying
@@ -108,12 +187,12 @@ trait Commands {
      *  is later used for verifying that the command behaved according
      *  to the specification, by the [[Command!.postCondition* postCondition]]
      *  method. */
-    def run(sut: Sut): Result
+    def run(sut: Sut, state: State): Result
 
     /** Returns a new [[State]] instance that represents the
      *  state of the system after this command has run, given the system
      *  was in the provided state before the run. */
-    def nextState(state: State): State
+    def nextState(state: State, v: Term[Result]): State
 
     /** Precondition that decides if this command is allowed to run
      *  when the system under test is in the provided state. */
@@ -126,9 +205,9 @@ trait Commands {
 
     /** Wraps the run and postCondition methods in order not to leak the
      *  dependant Result type. */
-    private[Commands] def runPC(sut: Sut): (Try[String], State => Prop) = {
+    private[Commands] def runPC(sut: Sut, state: State): (Try[String], State => Prop) = {
       import Prop.BooleanOperators
-      val r = Try(run(sut))
+      val r = Try(run(sut, state))
       (r.map(_.toString), s => preCondition(s) ==> postCondition(s,r))
     }
   }
@@ -154,41 +233,10 @@ trait Commands {
   /** A command that doesn't do anything */
   case object NoOp extends Command {
     type Result = Null
-    def run(sut: Sut) = null
-    def nextState(state: State) = state
+    def run(sut: Sut, state: State) = null
+    def nextState(state: State, v: Term[Null]) = state
     def preCondition(state: State) = true
     def postCondition(state: State, result: Try[Null]) = true
-  }
-
-  /** A command that runs a sequence of other commands.
-   *  All commands (and their post conditions) are executed even if some
-   *  command fails. Note that you probably can't use this method if you're
-   *  testing in parallel (`threadCount` larger than 1). This is because
-   *  ScalaCheck regards each command as atomic, even if the command
-   *  is a sequence of other commands. */
-  def commandSequence(head: Command, snd: Command, rest: Command*): Command =
-    CommandSequence(head, snd, rest: _*)
-
-  /** A command that runs a sequence of other commands */
-  private final case class CommandSequence(
-    head: Command, snd: Command, rest: Command*
-  ) extends SuccessCommand {
-    /* The tail of the command sequence */
-    val tail: Command =
-      if (rest.isEmpty) snd else CommandSequence(snd, rest.head, rest.tail: _*)
-
-    type Result = (Try[head.Result], Try[tail.Result])
-
-    def run(sut: Sut): Result = (Try(head.run(sut)), Try(tail.run(sut)))
-
-    def nextState(state: State): State = tail.nextState(head.nextState(state))
-
-    def preCondition(state: State): Boolean =
-      head.preCondition(state) && tail.preCondition(head.nextState(state))
-
-    def postCondition(state: State, result: Result): Prop =
-      head.postCondition(state, result._1) &&
-      tail.postCondition(head.nextState(state), result._2)
   }
 
   /** A property that can be used to test this [[Commands]] specification.
@@ -281,10 +329,17 @@ trait Commands {
   }
 
   private def runSeqCmds(sut: Sut, s0: State, cs: Commands
-  ): (Prop, State, List[Try[String]]) =
-    cs.foldLeft((Prop.proved,s0,List[Try[String]]())) { case ((p,s,rs),c) =>
-      val (r,pf) = c.runPC(sut)
-      (p && pf(s), c.nextState(s), rs :+ r)
+  ): (Prop, State, List[Try[String]]) = {
+    val (prop, finalState, labels, _) = cs.foldLeft((Prop.proved,s0,List[Try[String]](),1)) { 
+      case ((p,s,rs,count),c) => {
+        import Prop.BooleanOperators
+        val r = Try(c.run(sut, s))
+        val pf:State => Prop = st => c.preCondition(st) ==> c.postCondition(st,r)
+        val term = DynVar(Binding(count), r)
+        (p && pf(s), c.nextState(s,term), rs :+ r.map(_.toString), count + 1)
+      }
+    }
+    (prop, finalState, labels)
     }
 
   private def runParCmds(sut: Sut, s: State, pcmds: List[Commands]
@@ -296,15 +351,20 @@ trait Commands {
 
     def endStates(scss: (State, List[Commands])): List[State] = {
       val (s,css) = (scss._1, scss._2.filter(_.nonEmpty))
+      var count = 0
       (memo.get((s,css)),css) match {
         case (Some(states),_) => states
         case (_,Nil) => List(s)
         case (_,cs::Nil) =>
-          List(cs.init.foldLeft(s) { case (s0,c) => c.nextState(s0) })
+          List(cs.init.foldLeft(s) { case (s0,c) => {
+            count += 1
+            c.nextState(s0, SymbVar(count)) 
+          }})
         case _ =>
-          val inits = scan(css) { case (cs,x) =>
-            (cs.head.nextState(s), cs.tail::x)
-          }
+          val inits = scan(css) { case (cs,x) => {
+            count += 1
+            (cs.head.nextState(s, SymbVar(count)), cs.tail::x)
+          }}
           val states = inits.distinct.flatMap(endStates).distinct
           memo += (s,css) -> states
           states
@@ -314,8 +374,8 @@ trait Commands {
     def run(endStates: List[State], cs: Commands
     ): Future[(Prop,List[(Command,Try[String])])] = Future {
       if(cs.isEmpty) (Prop.proved, Nil) else blocking {
-        val rs = cs.init.map(_.runPC(sut)._1)
-        val (r,pf) = cs.last.runPC(sut)
+        val rs = cs.init.map(_.runPC(sut, s)._1)
+        val (r,pf) = cs.last.runPC(sut, s)
         (Prop.atLeastOne(endStates.map(pf): _*), cs.zip(rs :+ r))
       }
     }
@@ -363,24 +423,28 @@ trait Commands {
 
     def sizedCmds(s: State)(sz: Int): Gen[(State,Commands)] = {
       val l: List[Unit] = List.fill(sz)(())
+      var count = 0
       l.foldLeft(const((s,Nil:Commands))) { case (g,()) =>
         for {
           (s0,cs) <- g
           c <- genCommand(s0) suchThat (_.preCondition(s0))
-        } yield (c.nextState(s0), cs :+ c)
+        } yield {
+          count += 1
+          (c.nextState(s0, SymbVar(count)), cs :+ c)
+        }
       }
     }
 
-    def cmdsPrecond(s: State, cmds: Commands): (State,Boolean) = cmds match {
+    def cmdsPrecond(s: State, cmds: Commands, count: Int): (State,Boolean) = cmds match {
       case Nil => (s,true)
-      case c::cs if c.preCondition(s) => cmdsPrecond(c.nextState(s), cs)
+      case c::cs if c.preCondition(s) => cmdsPrecond(c.nextState(s, SymbVar(count)), cs, count + 1)
       case _ => (s,false)
     }
 
     def actionsPrecond(as: Actions) =
       as.parCmds.length != 1 && as.parCmds.forall(_.nonEmpty) &&
-      initialPreCondition(as.s) && (cmdsPrecond(as.s, as.seqCmds) match {
-        case (s,true) => as.parCmds.forall(cmdsPrecond(s,_)._2)
+      initialPreCondition(as.s) && (cmdsPrecond(as.s, as.seqCmds, 1) match {
+        case (s,true) => as.parCmds.forall(cmdsPrecond(s,_,1)._2)
         case _ => false
       })
 

--- a/src/main/scala/org/scalacheck/commands/Commands.scala
+++ b/src/main/scala/org/scalacheck/commands/Commands.scala
@@ -75,6 +75,7 @@ trait Commands {
       if(isEmpty) alternative else Some(this.get.get)
   }
   
+  
    /**
    * A Binding is a (per SUT) unique identifier, basically a wrapped int with a nicer name. This helps clarify
    * intent, if you need to keep track of term bindings in your State, e.g. a Map[String, Binding]
@@ -314,7 +315,7 @@ trait Commands {
   // Private methods //
   private type Commands = List[Command]
 
-  private case class Actions(
+  case class Actions(
     s: State, seqCmds: Commands, parCmds: List[Commands]
   )
 


### PR DESCRIPTION
Notable points:

1) Unfortunately, due to the way CommandSequence works, I was not able to find any way to 'fix' it with the new arguments added to run/nextState(), so I've had to remove CommandSequence. Mainly, calling nextState() from a preCondition() is a violation of the way QuickCheck works, and cannot be (as far as I can see) represented now that there is a Term argument to nextState().

2) I'm still not entirely convinced on my implementation of Term, but it works without too much effort. CommandPidSpecification shows the process registry example from QuickCheck: For Fun & Profit, which is now possible due to symbolic terms. A more advanced version can be found in CommandMultiPidSpecification, where one method returns a List of PIDs, instead of there being an add method that adds a single one. This is much harder to deal with, because you have no way of knowing how big the List will actually be before run() is executed.