### PR TITLE
[Spike] Make coded overrideParameters for Properties possible

### DIFF
--- a/src/main/scala/org/scalacheck/Prop.scala
+++ b/src/main/scala/org/scalacheck/Prop.scala
@@ -86,7 +86,8 @@ sealed abstract class Prop {
    *  with a non-zero exit code if the property check fails. */
   def main(args: Array[String]): Unit = {
     val ret = Test.cmdLineParser.parseParams(args) match {
-      case (params, Nil) =>
+      case (applyCmdParams, Nil) =>
+        val params = applyCmdParams(Test.Parameters.default)
         if (Test.check(params, this).passed) 0
         else 1
       case (_, os) =>

--- a/src/main/scala/org/scalacheck/Properties.scala
+++ b/src/main/scala/org/scalacheck/Properties.scala
@@ -62,7 +62,8 @@ class Properties(val name: String) {
    *  with the exit code set to the number of failed properties. */
   def main(args: Array[String]): Unit = {
     val ret = Test.cmdLineParser.parseParams(args) match {
-      case (params, Nil) =>
+      case (applyCmdParams, Nil) =>
+        val params = applyCmdParams(overrideParameters(Test.Parameters.default))
         val res = Test.checkProperties(params, this)
         val failed = res.filter(!_._2.passed).size
         failed

--- a/src/main/scala/org/scalacheck/Test.scala
+++ b/src/main/scala/org/scalacheck/Test.scala
@@ -242,9 +242,9 @@ object Test {
       OptMaxSize, OptWorkers, OptVerbosity
     )
 
-    def parseParams(args: Array[String]): (Parameters, List[String]) = {
+    def parseParams(args: Array[String]): (Parameters => Parameters, List[String]) = {
       val (optMap, us) = parseArgs(args)
-      val params = Parameters.default
+      val params = (p: Parameters) => p
         .withMinSuccessfulTests(optMap(OptMinSuccess): Int)
         .withMaxDiscardRatio(optMap(OptMaxDiscardRatio): Float)
         .withMinSize(optMap(OptMinSize): Int)


### PR DESCRIPTION
An attempt to fix #233 
`Test.parseParams` returns a func `Parameters => Parameters` that applies cmd parameters. It makes possible to have a chain: `default params => coded overwrite => cmd overwrite`

What do you think?