### PR TITLE
Avoid empty generators when possible (take 2)

### DIFF
--- a/src/main/scala/org/scalacheck/GenArities.scala
+++ b/src/main/scala/org/scalacheck/GenArities.scala
@@ -12,7 +12,7 @@ private[scalacheck] trait GenArities{
   def function1[T1,Z](g: Gen[Z])(implicit co1: Cogen[T1]): Gen[(T1) => Z] =
     Gen.gen { (p, seed0) =>
       val f: (T1) => Z =
-        (t1: T1) => g.doApply(p, co1.perturb(seed0, t1)).retrieve.get
+        (t1: T1) => g.pureApply(p, co1.perturb(seed0, t1))
       new Gen.R[(T1) => Z] {
         val result = Some(f)
         val seed = seed0.next
@@ -23,7 +23,7 @@ private[scalacheck] trait GenArities{
   def function2[T1,T2,Z](g: Gen[Z])(implicit co1: Cogen[T1],co2: Cogen[T2]): Gen[(T1,T2) => Z] =
     Gen.gen { (p, seed0) =>
       val f: (T1,T2) => Z =
-        (t1: T1,t2: T2) => g.doApply(p, co2.perturb(co1.perturb(seed0, t1), t2)).retrieve.get
+        (t1: T1,t2: T2) => g.pureApply(p, co2.perturb(co1.perturb(seed0, t1), t2))
       new Gen.R[(T1,T2) => Z] {
         val result = Some(f)
         val seed = seed0.next
@@ -34,7 +34,7 @@ private[scalacheck] trait GenArities{
   def function3[T1,T2,T3,Z](g: Gen[Z])(implicit co1: Cogen[T1],co2: Cogen[T2],co3: Cogen[T3]): Gen[(T1,T2,T3) => Z] =
     Gen.gen { (p, seed0) =>
       val f: (T1,T2,T3) => Z =
-        (t1: T1,t2: T2,t3: T3) => g.doApply(p, co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3)).retrieve.get
+        (t1: T1,t2: T2,t3: T3) => g.pureApply(p, co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3))
       new Gen.R[(T1,T2,T3) => Z] {
         val result = Some(f)
         val seed = seed0.next
@@ -45,7 +45,7 @@ private[scalacheck] trait GenArities{
   def function4[T1,T2,T3,T4,Z](g: Gen[Z])(implicit co1: Cogen[T1],co2: Cogen[T2],co3: Cogen[T3],co4: Cogen[T4]): Gen[(T1,T2,T3,T4) => Z] =
     Gen.gen { (p, seed0) =>
       val f: (T1,T2,T3,T4) => Z =
-        (t1: T1,t2: T2,t3: T3,t4: T4) => g.doApply(p, co4.perturb(co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3), t4)).retrieve.get
+        (t1: T1,t2: T2,t3: T3,t4: T4) => g.pureApply(p, co4.perturb(co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3), t4))
       new Gen.R[(T1,T2,T3,T4) => Z] {
         val result = Some(f)
         val seed = seed0.next
@@ -56,7 +56,7 @@ private[scalacheck] trait GenArities{
   def function5[T1,T2,T3,T4,T5,Z](g: Gen[Z])(implicit co1: Cogen[T1],co2: Cogen[T2],co3: Cogen[T3],co4: Cogen[T4],co5: Cogen[T5]): Gen[(T1,T2,T3,T4,T5) => Z] =
     Gen.gen { (p, seed0) =>
       val f: (T1,T2,T3,T4,T5) => Z =
-        (t1: T1,t2: T2,t3: T3,t4: T4,t5: T5) => g.doApply(p, co5.perturb(co4.perturb(co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3), t4), t5)).retrieve.get
+        (t1: T1,t2: T2,t3: T3,t4: T4,t5: T5) => g.pureApply(p, co5.perturb(co4.perturb(co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3), t4), t5))
       new Gen.R[(T1,T2,T3,T4,T5) => Z] {
         val result = Some(f)
         val seed = seed0.next
@@ -67,7 +67,7 @@ private[scalacheck] trait GenArities{
   def function6[T1,T2,T3,T4,T5,T6,Z](g: Gen[Z])(implicit co1: Cogen[T1],co2: Cogen[T2],co3: Cogen[T3],co4: Cogen[T4],co5: Cogen[T5],co6: Cogen[T6]): Gen[(T1,T2,T3,T4,T5,T6) => Z] =
     Gen.gen { (p, seed0) =>
       val f: (T1,T2,T3,T4,T5,T6) => Z =
-        (t1: T1,t2: T2,t3: T3,t4: T4,t5: T5,t6: T6) => g.doApply(p, co6.perturb(co5.perturb(co4.perturb(co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3), t4), t5), t6)).retrieve.get
+        (t1: T1,t2: T2,t3: T3,t4: T4,t5: T5,t6: T6) => g.pureApply(p, co6.perturb(co5.perturb(co4.perturb(co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3), t4), t5), t6))
       new Gen.R[(T1,T2,T3,T4,T5,T6) => Z] {
         val result = Some(f)
         val seed = seed0.next
@@ -78,7 +78,7 @@ private[scalacheck] trait GenArities{
   def function7[T1,T2,T3,T4,T5,T6,T7,Z](g: Gen[Z])(implicit co1: Cogen[T1],co2: Cogen[T2],co3: Cogen[T3],co4: Cogen[T4],co5: Cogen[T5],co6: Cogen[T6],co7: Cogen[T7]): Gen[(T1,T2,T3,T4,T5,T6,T7) => Z] =
     Gen.gen { (p, seed0) =>
       val f: (T1,T2,T3,T4,T5,T6,T7) => Z =
-        (t1: T1,t2: T2,t3: T3,t4: T4,t5: T5,t6: T6,t7: T7) => g.doApply(p, co7.perturb(co6.perturb(co5.perturb(co4.perturb(co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3), t4), t5), t6), t7)).retrieve.get
+        (t1: T1,t2: T2,t3: T3,t4: T4,t5: T5,t6: T6,t7: T7) => g.pureApply(p, co7.perturb(co6.perturb(co5.perturb(co4.perturb(co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3), t4), t5), t6), t7))
       new Gen.R[(T1,T2,T3,T4,T5,T6,T7) => Z] {
         val result = Some(f)
         val seed = seed0.next
@@ -89,7 +89,7 @@ private[scalacheck] trait GenArities{
   def function8[T1,T2,T3,T4,T5,T6,T7,T8,Z](g: Gen[Z])(implicit co1: Cogen[T1],co2: Cogen[T2],co3: Cogen[T3],co4: Cogen[T4],co5: Cogen[T5],co6: Cogen[T6],co7: Cogen[T7],co8: Cogen[T8]): Gen[(T1,T2,T3,T4,T5,T6,T7,T8) => Z] =
     Gen.gen { (p, seed0) =>
       val f: (T1,T2,T3,T4,T5,T6,T7,T8) => Z =
-        (t1: T1,t2: T2,t3: T3,t4: T4,t5: T5,t6: T6,t7: T7,t8: T8) => g.doApply(p, co8.perturb(co7.perturb(co6.perturb(co5.perturb(co4.perturb(co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3), t4), t5), t6), t7), t8)).retrieve.get
+        (t1: T1,t2: T2,t3: T3,t4: T4,t5: T5,t6: T6,t7: T7,t8: T8) => g.pureApply(p, co8.perturb(co7.perturb(co6.perturb(co5.perturb(co4.perturb(co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3), t4), t5), t6), t7), t8))
       new Gen.R[(T1,T2,T3,T4,T5,T6,T7,T8) => Z] {
         val result = Some(f)
         val seed = seed0.next
@@ -100,7 +100,7 @@ private[scalacheck] trait GenArities{
   def function9[T1,T2,T3,T4,T5,T6,T7,T8,T9,Z](g: Gen[Z])(implicit co1: Cogen[T1],co2: Cogen[T2],co3: Cogen[T3],co4: Cogen[T4],co5: Cogen[T5],co6: Cogen[T6],co7: Cogen[T7],co8: Cogen[T8],co9: Cogen[T9]): Gen[(T1,T2,T3,T4,T5,T6,T7,T8,T9) => Z] =
     Gen.gen { (p, seed0) =>
       val f: (T1,T2,T3,T4,T5,T6,T7,T8,T9) => Z =
-        (t1: T1,t2: T2,t3: T3,t4: T4,t5: T5,t6: T6,t7: T7,t8: T8,t9: T9) => g.doApply(p, co9.perturb(co8.perturb(co7.perturb(co6.perturb(co5.perturb(co4.perturb(co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3), t4), t5), t6), t7), t8), t9)).retrieve.get
+        (t1: T1,t2: T2,t3: T3,t4: T4,t5: T5,t6: T6,t7: T7,t8: T8,t9: T9) => g.pureApply(p, co9.perturb(co8.perturb(co7.perturb(co6.perturb(co5.perturb(co4.perturb(co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3), t4), t5), t6), t7), t8), t9))
       new Gen.R[(T1,T2,T3,T4,T5,T6,T7,T8,T9) => Z] {
         val result = Some(f)
         val seed = seed0.next
@@ -111,7 +111,7 @@ private[scalacheck] trait GenArities{
   def function10[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,Z](g: Gen[Z])(implicit co1: Cogen[T1],co2: Cogen[T2],co3: Cogen[T3],co4: Cogen[T4],co5: Cogen[T5],co6: Cogen[T6],co7: Cogen[T7],co8: Cogen[T8],co9: Cogen[T9],co10: Cogen[T10]): Gen[(T1,T2,T3,T4,T5,T6,T7,T8,T9,T10) => Z] =
     Gen.gen { (p, seed0) =>
       val f: (T1,T2,T3,T4,T5,T6,T7,T8,T9,T10) => Z =
-        (t1: T1,t2: T2,t3: T3,t4: T4,t5: T5,t6: T6,t7: T7,t8: T8,t9: T9,t10: T10) => g.doApply(p, co10.perturb(co9.perturb(co8.perturb(co7.perturb(co6.perturb(co5.perturb(co4.perturb(co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3), t4), t5), t6), t7), t8), t9), t10)).retrieve.get
+        (t1: T1,t2: T2,t3: T3,t4: T4,t5: T5,t6: T6,t7: T7,t8: T8,t9: T9,t10: T10) => g.pureApply(p, co10.perturb(co9.perturb(co8.perturb(co7.perturb(co6.perturb(co5.perturb(co4.perturb(co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3), t4), t5), t6), t7), t8), t9), t10))
       new Gen.R[(T1,T2,T3,T4,T5,T6,T7,T8,T9,T10) => Z] {
         val result = Some(f)
         val seed = seed0.next
@@ -122,7 +122,7 @@ private[scalacheck] trait GenArities{
   def function11[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,Z](g: Gen[Z])(implicit co1: Cogen[T1],co2: Cogen[T2],co3: Cogen[T3],co4: Cogen[T4],co5: Cogen[T5],co6: Cogen[T6],co7: Cogen[T7],co8: Cogen[T8],co9: Cogen[T9],co10: Cogen[T10],co11: Cogen[T11]): Gen[(T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11) => Z] =
     Gen.gen { (p, seed0) =>
       val f: (T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11) => Z =
-        (t1: T1,t2: T2,t3: T3,t4: T4,t5: T5,t6: T6,t7: T7,t8: T8,t9: T9,t10: T10,t11: T11) => g.doApply(p, co11.perturb(co10.perturb(co9.perturb(co8.perturb(co7.perturb(co6.perturb(co5.perturb(co4.perturb(co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3), t4), t5), t6), t7), t8), t9), t10), t11)).retrieve.get
+        (t1: T1,t2: T2,t3: T3,t4: T4,t5: T5,t6: T6,t7: T7,t8: T8,t9: T9,t10: T10,t11: T11) => g.pureApply(p, co11.perturb(co10.perturb(co9.perturb(co8.perturb(co7.perturb(co6.perturb(co5.perturb(co4.perturb(co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3), t4), t5), t6), t7), t8), t9), t10), t11))
       new Gen.R[(T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11) => Z] {
         val result = Some(f)
         val seed = seed0.next
@@ -133,7 +133,7 @@ private[scalacheck] trait GenArities{
   def function12[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,Z](g: Gen[Z])(implicit co1: Cogen[T1],co2: Cogen[T2],co3: Cogen[T3],co4: Cogen[T4],co5: Cogen[T5],co6: Cogen[T6],co7: Cogen[T7],co8: Cogen[T8],co9: Cogen[T9],co10: Cogen[T10],co11: Cogen[T11],co12: Cogen[T12]): Gen[(T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12) => Z] =
     Gen.gen { (p, seed0) =>
       val f: (T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12) => Z =
-        (t1: T1,t2: T2,t3: T3,t4: T4,t5: T5,t6: T6,t7: T7,t8: T8,t9: T9,t10: T10,t11: T11,t12: T12) => g.doApply(p, co12.perturb(co11.perturb(co10.perturb(co9.perturb(co8.perturb(co7.perturb(co6.perturb(co5.perturb(co4.perturb(co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3), t4), t5), t6), t7), t8), t9), t10), t11), t12)).retrieve.get
+        (t1: T1,t2: T2,t3: T3,t4: T4,t5: T5,t6: T6,t7: T7,t8: T8,t9: T9,t10: T10,t11: T11,t12: T12) => g.pureApply(p, co12.perturb(co11.perturb(co10.perturb(co9.perturb(co8.perturb(co7.perturb(co6.perturb(co5.perturb(co4.perturb(co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3), t4), t5), t6), t7), t8), t9), t10), t11), t12))
       new Gen.R[(T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12) => Z] {
         val result = Some(f)
         val seed = seed0.next
@@ -144,7 +144,7 @@ private[scalacheck] trait GenArities{
   def function13[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,Z](g: Gen[Z])(implicit co1: Cogen[T1],co2: Cogen[T2],co3: Cogen[T3],co4: Cogen[T4],co5: Cogen[T5],co6: Cogen[T6],co7: Cogen[T7],co8: Cogen[T8],co9: Cogen[T9],co10: Cogen[T10],co11: Cogen[T11],co12: Cogen[T12],co13: Cogen[T13]): Gen[(T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13) => Z] =
     Gen.gen { (p, seed0) =>
       val f: (T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13) => Z =
-        (t1: T1,t2: T2,t3: T3,t4: T4,t5: T5,t6: T6,t7: T7,t8: T8,t9: T9,t10: T10,t11: T11,t12: T12,t13: T13) => g.doApply(p, co13.perturb(co12.perturb(co11.perturb(co10.perturb(co9.perturb(co8.perturb(co7.perturb(co6.perturb(co5.perturb(co4.perturb(co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3), t4), t5), t6), t7), t8), t9), t10), t11), t12), t13)).retrieve.get
+        (t1: T1,t2: T2,t3: T3,t4: T4,t5: T5,t6: T6,t7: T7,t8: T8,t9: T9,t10: T10,t11: T11,t12: T12,t13: T13) => g.pureApply(p, co13.perturb(co12.perturb(co11.perturb(co10.perturb(co9.perturb(co8.perturb(co7.perturb(co6.perturb(co5.perturb(co4.perturb(co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3), t4), t5), t6), t7), t8), t9), t10), t11), t12), t13))
       new Gen.R[(T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13) => Z] {
         val result = Some(f)
         val seed = seed0.next
@@ -155,7 +155,7 @@ private[scalacheck] trait GenArities{
   def function14[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,Z](g: Gen[Z])(implicit co1: Cogen[T1],co2: Cogen[T2],co3: Cogen[T3],co4: Cogen[T4],co5: Cogen[T5],co6: Cogen[T6],co7: Cogen[T7],co8: Cogen[T8],co9: Cogen[T9],co10: Cogen[T10],co11: Cogen[T11],co12: Cogen[T12],co13: Cogen[T13],co14: Cogen[T14]): Gen[(T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14) => Z] =
     Gen.gen { (p, seed0) =>
       val f: (T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14) => Z =
-        (t1: T1,t2: T2,t3: T3,t4: T4,t5: T5,t6: T6,t7: T7,t8: T8,t9: T9,t10: T10,t11: T11,t12: T12,t13: T13,t14: T14) => g.doApply(p, co14.perturb(co13.perturb(co12.perturb(co11.perturb(co10.perturb(co9.perturb(co8.perturb(co7.perturb(co6.perturb(co5.perturb(co4.perturb(co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3), t4), t5), t6), t7), t8), t9), t10), t11), t12), t13), t14)).retrieve.get
+        (t1: T1,t2: T2,t3: T3,t4: T4,t5: T5,t6: T6,t7: T7,t8: T8,t9: T9,t10: T10,t11: T11,t12: T12,t13: T13,t14: T14) => g.pureApply(p, co14.perturb(co13.perturb(co12.perturb(co11.perturb(co10.perturb(co9.perturb(co8.perturb(co7.perturb(co6.perturb(co5.perturb(co4.perturb(co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3), t4), t5), t6), t7), t8), t9), t10), t11), t12), t13), t14))
       new Gen.R[(T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14) => Z] {
         val result = Some(f)
         val seed = seed0.next
@@ -166,7 +166,7 @@ private[scalacheck] trait GenArities{
   def function15[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,Z](g: Gen[Z])(implicit co1: Cogen[T1],co2: Cogen[T2],co3: Cogen[T3],co4: Cogen[T4],co5: Cogen[T5],co6: Cogen[T6],co7: Cogen[T7],co8: Cogen[T8],co9: Cogen[T9],co10: Cogen[T10],co11: Cogen[T11],co12: Cogen[T12],co13: Cogen[T13],co14: Cogen[T14],co15: Cogen[T15]): Gen[(T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15) => Z] =
     Gen.gen { (p, seed0) =>
       val f: (T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15) => Z =
-        (t1: T1,t2: T2,t3: T3,t4: T4,t5: T5,t6: T6,t7: T7,t8: T8,t9: T9,t10: T10,t11: T11,t12: T12,t13: T13,t14: T14,t15: T15) => g.doApply(p, co15.perturb(co14.perturb(co13.perturb(co12.perturb(co11.perturb(co10.perturb(co9.perturb(co8.perturb(co7.perturb(co6.perturb(co5.perturb(co4.perturb(co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3), t4), t5), t6), t7), t8), t9), t10), t11), t12), t13), t14), t15)).retrieve.get
+        (t1: T1,t2: T2,t3: T3,t4: T4,t5: T5,t6: T6,t7: T7,t8: T8,t9: T9,t10: T10,t11: T11,t12: T12,t13: T13,t14: T14,t15: T15) => g.pureApply(p, co15.perturb(co14.perturb(co13.perturb(co12.perturb(co11.perturb(co10.perturb(co9.perturb(co8.perturb(co7.perturb(co6.perturb(co5.perturb(co4.perturb(co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3), t4), t5), t6), t7), t8), t9), t10), t11), t12), t13), t14), t15))
       new Gen.R[(T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15) => Z] {
         val result = Some(f)
         val seed = seed0.next
@@ -177,7 +177,7 @@ private[scalacheck] trait GenArities{
   def function16[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,Z](g: Gen[Z])(implicit co1: Cogen[T1],co2: Cogen[T2],co3: Cogen[T3],co4: Cogen[T4],co5: Cogen[T5],co6: Cogen[T6],co7: Cogen[T7],co8: Cogen[T8],co9: Cogen[T9],co10: Cogen[T10],co11: Cogen[T11],co12: Cogen[T12],co13: Cogen[T13],co14: Cogen[T14],co15: Cogen[T15],co16: Cogen[T16]): Gen[(T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16) => Z] =
     Gen.gen { (p, seed0) =>
       val f: (T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16) => Z =
-        (t1: T1,t2: T2,t3: T3,t4: T4,t5: T5,t6: T6,t7: T7,t8: T8,t9: T9,t10: T10,t11: T11,t12: T12,t13: T13,t14: T14,t15: T15,t16: T16) => g.doApply(p, co16.perturb(co15.perturb(co14.perturb(co13.perturb(co12.perturb(co11.perturb(co10.perturb(co9.perturb(co8.perturb(co7.perturb(co6.perturb(co5.perturb(co4.perturb(co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3), t4), t5), t6), t7), t8), t9), t10), t11), t12), t13), t14), t15), t16)).retrieve.get
+        (t1: T1,t2: T2,t3: T3,t4: T4,t5: T5,t6: T6,t7: T7,t8: T8,t9: T9,t10: T10,t11: T11,t12: T12,t13: T13,t14: T14,t15: T15,t16: T16) => g.pureApply(p, co16.perturb(co15.perturb(co14.perturb(co13.perturb(co12.perturb(co11.perturb(co10.perturb(co9.perturb(co8.perturb(co7.perturb(co6.perturb(co5.perturb(co4.perturb(co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3), t4), t5), t6), t7), t8), t9), t10), t11), t12), t13), t14), t15), t16))
       new Gen.R[(T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16) => Z] {
         val result = Some(f)
         val seed = seed0.next
@@ -188,7 +188,7 @@ private[scalacheck] trait GenArities{
   def function17[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,Z](g: Gen[Z])(implicit co1: Cogen[T1],co2: Cogen[T2],co3: Cogen[T3],co4: Cogen[T4],co5: Cogen[T5],co6: Cogen[T6],co7: Cogen[T7],co8: Cogen[T8],co9: Cogen[T9],co10: Cogen[T10],co11: Cogen[T11],co12: Cogen[T12],co13: Cogen[T13],co14: Cogen[T14],co15: Cogen[T15],co16: Cogen[T16],co17: Cogen[T17]): Gen[(T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17) => Z] =
     Gen.gen { (p, seed0) =>
       val f: (T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17) => Z =
-        (t1: T1,t2: T2,t3: T3,t4: T4,t5: T5,t6: T6,t7: T7,t8: T8,t9: T9,t10: T10,t11: T11,t12: T12,t13: T13,t14: T14,t15: T15,t16: T16,t17: T17) => g.doApply(p, co17.perturb(co16.perturb(co15.perturb(co14.perturb(co13.perturb(co12.perturb(co11.perturb(co10.perturb(co9.perturb(co8.perturb(co7.perturb(co6.perturb(co5.perturb(co4.perturb(co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3), t4), t5), t6), t7), t8), t9), t10), t11), t12), t13), t14), t15), t16), t17)).retrieve.get
+        (t1: T1,t2: T2,t3: T3,t4: T4,t5: T5,t6: T6,t7: T7,t8: T8,t9: T9,t10: T10,t11: T11,t12: T12,t13: T13,t14: T14,t15: T15,t16: T16,t17: T17) => g.pureApply(p, co17.perturb(co16.perturb(co15.perturb(co14.perturb(co13.perturb(co12.perturb(co11.perturb(co10.perturb(co9.perturb(co8.perturb(co7.perturb(co6.perturb(co5.perturb(co4.perturb(co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3), t4), t5), t6), t7), t8), t9), t10), t11), t12), t13), t14), t15), t16), t17))
       new Gen.R[(T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17) => Z] {
         val result = Some(f)
         val seed = seed0.next
@@ -199,7 +199,7 @@ private[scalacheck] trait GenArities{
   def function18[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,Z](g: Gen[Z])(implicit co1: Cogen[T1],co2: Cogen[T2],co3: Cogen[T3],co4: Cogen[T4],co5: Cogen[T5],co6: Cogen[T6],co7: Cogen[T7],co8: Cogen[T8],co9: Cogen[T9],co10: Cogen[T10],co11: Cogen[T11],co12: Cogen[T12],co13: Cogen[T13],co14: Cogen[T14],co15: Cogen[T15],co16: Cogen[T16],co17: Cogen[T17],co18: Cogen[T18]): Gen[(T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18) => Z] =
     Gen.gen { (p, seed0) =>
       val f: (T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18) => Z =
-        (t1: T1,t2: T2,t3: T3,t4: T4,t5: T5,t6: T6,t7: T7,t8: T8,t9: T9,t10: T10,t11: T11,t12: T12,t13: T13,t14: T14,t15: T15,t16: T16,t17: T17,t18: T18) => g.doApply(p, co18.perturb(co17.perturb(co16.perturb(co15.perturb(co14.perturb(co13.perturb(co12.perturb(co11.perturb(co10.perturb(co9.perturb(co8.perturb(co7.perturb(co6.perturb(co5.perturb(co4.perturb(co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3), t4), t5), t6), t7), t8), t9), t10), t11), t12), t13), t14), t15), t16), t17), t18)).retrieve.get
+        (t1: T1,t2: T2,t3: T3,t4: T4,t5: T5,t6: T6,t7: T7,t8: T8,t9: T9,t10: T10,t11: T11,t12: T12,t13: T13,t14: T14,t15: T15,t16: T16,t17: T17,t18: T18) => g.pureApply(p, co18.perturb(co17.perturb(co16.perturb(co15.perturb(co14.perturb(co13.perturb(co12.perturb(co11.perturb(co10.perturb(co9.perturb(co8.perturb(co7.perturb(co6.perturb(co5.perturb(co4.perturb(co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3), t4), t5), t6), t7), t8), t9), t10), t11), t12), t13), t14), t15), t16), t17), t18))
       new Gen.R[(T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18) => Z] {
         val result = Some(f)
         val seed = seed0.next
@@ -210,7 +210,7 @@ private[scalacheck] trait GenArities{
   def function19[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,Z](g: Gen[Z])(implicit co1: Cogen[T1],co2: Cogen[T2],co3: Cogen[T3],co4: Cogen[T4],co5: Cogen[T5],co6: Cogen[T6],co7: Cogen[T7],co8: Cogen[T8],co9: Cogen[T9],co10: Cogen[T10],co11: Cogen[T11],co12: Cogen[T12],co13: Cogen[T13],co14: Cogen[T14],co15: Cogen[T15],co16: Cogen[T16],co17: Cogen[T17],co18: Cogen[T18],co19: Cogen[T19]): Gen[(T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19) => Z] =
     Gen.gen { (p, seed0) =>
       val f: (T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19) => Z =
-        (t1: T1,t2: T2,t3: T3,t4: T4,t5: T5,t6: T6,t7: T7,t8: T8,t9: T9,t10: T10,t11: T11,t12: T12,t13: T13,t14: T14,t15: T15,t16: T16,t17: T17,t18: T18,t19: T19) => g.doApply(p, co19.perturb(co18.perturb(co17.perturb(co16.perturb(co15.perturb(co14.perturb(co13.perturb(co12.perturb(co11.perturb(co10.perturb(co9.perturb(co8.perturb(co7.perturb(co6.perturb(co5.perturb(co4.perturb(co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3), t4), t5), t6), t7), t8), t9), t10), t11), t12), t13), t14), t15), t16), t17), t18), t19)).retrieve.get
+        (t1: T1,t2: T2,t3: T3,t4: T4,t5: T5,t6: T6,t7: T7,t8: T8,t9: T9,t10: T10,t11: T11,t12: T12,t13: T13,t14: T14,t15: T15,t16: T16,t17: T17,t18: T18,t19: T19) => g.pureApply(p, co19.perturb(co18.perturb(co17.perturb(co16.perturb(co15.perturb(co14.perturb(co13.perturb(co12.perturb(co11.perturb(co10.perturb(co9.perturb(co8.perturb(co7.perturb(co6.perturb(co5.perturb(co4.perturb(co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3), t4), t5), t6), t7), t8), t9), t10), t11), t12), t13), t14), t15), t16), t17), t18), t19))
       new Gen.R[(T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19) => Z] {
         val result = Some(f)
         val seed = seed0.next
@@ -221,7 +221,7 @@ private[scalacheck] trait GenArities{
   def function20[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,Z](g: Gen[Z])(implicit co1: Cogen[T1],co2: Cogen[T2],co3: Cogen[T3],co4: Cogen[T4],co5: Cogen[T5],co6: Cogen[T6],co7: Cogen[T7],co8: Cogen[T8],co9: Cogen[T9],co10: Cogen[T10],co11: Cogen[T11],co12: Cogen[T12],co13: Cogen[T13],co14: Cogen[T14],co15: Cogen[T15],co16: Cogen[T16],co17: Cogen[T17],co18: Cogen[T18],co19: Cogen[T19],co20: Cogen[T20]): Gen[(T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20) => Z] =
     Gen.gen { (p, seed0) =>
       val f: (T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20) => Z =
-        (t1: T1,t2: T2,t3: T3,t4: T4,t5: T5,t6: T6,t7: T7,t8: T8,t9: T9,t10: T10,t11: T11,t12: T12,t13: T13,t14: T14,t15: T15,t16: T16,t17: T17,t18: T18,t19: T19,t20: T20) => g.doApply(p, co20.perturb(co19.perturb(co18.perturb(co17.perturb(co16.perturb(co15.perturb(co14.perturb(co13.perturb(co12.perturb(co11.perturb(co10.perturb(co9.perturb(co8.perturb(co7.perturb(co6.perturb(co5.perturb(co4.perturb(co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3), t4), t5), t6), t7), t8), t9), t10), t11), t12), t13), t14), t15), t16), t17), t18), t19), t20)).retrieve.get
+        (t1: T1,t2: T2,t3: T3,t4: T4,t5: T5,t6: T6,t7: T7,t8: T8,t9: T9,t10: T10,t11: T11,t12: T12,t13: T13,t14: T14,t15: T15,t16: T16,t17: T17,t18: T18,t19: T19,t20: T20) => g.pureApply(p, co20.perturb(co19.perturb(co18.perturb(co17.perturb(co16.perturb(co15.perturb(co14.perturb(co13.perturb(co12.perturb(co11.perturb(co10.perturb(co9.perturb(co8.perturb(co7.perturb(co6.perturb(co5.perturb(co4.perturb(co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3), t4), t5), t6), t7), t8), t9), t10), t11), t12), t13), t14), t15), t16), t17), t18), t19), t20))
       new Gen.R[(T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20) => Z] {
         val result = Some(f)
         val seed = seed0.next
@@ -232,7 +232,7 @@ private[scalacheck] trait GenArities{
   def function21[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21,Z](g: Gen[Z])(implicit co1: Cogen[T1],co2: Cogen[T2],co3: Cogen[T3],co4: Cogen[T4],co5: Cogen[T5],co6: Cogen[T6],co7: Cogen[T7],co8: Cogen[T8],co9: Cogen[T9],co10: Cogen[T10],co11: Cogen[T11],co12: Cogen[T12],co13: Cogen[T13],co14: Cogen[T14],co15: Cogen[T15],co16: Cogen[T16],co17: Cogen[T17],co18: Cogen[T18],co19: Cogen[T19],co20: Cogen[T20],co21: Cogen[T21]): Gen[(T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21) => Z] =
     Gen.gen { (p, seed0) =>
       val f: (T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21) => Z =
-        (t1: T1,t2: T2,t3: T3,t4: T4,t5: T5,t6: T6,t7: T7,t8: T8,t9: T9,t10: T10,t11: T11,t12: T12,t13: T13,t14: T14,t15: T15,t16: T16,t17: T17,t18: T18,t19: T19,t20: T20,t21: T21) => g.doApply(p, co21.perturb(co20.perturb(co19.perturb(co18.perturb(co17.perturb(co16.perturb(co15.perturb(co14.perturb(co13.perturb(co12.perturb(co11.perturb(co10.perturb(co9.perturb(co8.perturb(co7.perturb(co6.perturb(co5.perturb(co4.perturb(co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3), t4), t5), t6), t7), t8), t9), t10), t11), t12), t13), t14), t15), t16), t17), t18), t19), t20), t21)).retrieve.get
+        (t1: T1,t2: T2,t3: T3,t4: T4,t5: T5,t6: T6,t7: T7,t8: T8,t9: T9,t10: T10,t11: T11,t12: T12,t13: T13,t14: T14,t15: T15,t16: T16,t17: T17,t18: T18,t19: T19,t20: T20,t21: T21) => g.pureApply(p, co21.perturb(co20.perturb(co19.perturb(co18.perturb(co17.perturb(co16.perturb(co15.perturb(co14.perturb(co13.perturb(co12.perturb(co11.perturb(co10.perturb(co9.perturb(co8.perturb(co7.perturb(co6.perturb(co5.perturb(co4.perturb(co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3), t4), t5), t6), t7), t8), t9), t10), t11), t12), t13), t14), t15), t16), t17), t18), t19), t20), t21))
       new Gen.R[(T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21) => Z] {
         val result = Some(f)
         val seed = seed0.next
@@ -243,7 +243,7 @@ private[scalacheck] trait GenArities{
   def function22[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21,T22,Z](g: Gen[Z])(implicit co1: Cogen[T1],co2: Cogen[T2],co3: Cogen[T3],co4: Cogen[T4],co5: Cogen[T5],co6: Cogen[T6],co7: Cogen[T7],co8: Cogen[T8],co9: Cogen[T9],co10: Cogen[T10],co11: Cogen[T11],co12: Cogen[T12],co13: Cogen[T13],co14: Cogen[T14],co15: Cogen[T15],co16: Cogen[T16],co17: Cogen[T17],co18: Cogen[T18],co19: Cogen[T19],co20: Cogen[T20],co21: Cogen[T21],co22: Cogen[T22]): Gen[(T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21,T22) => Z] =
     Gen.gen { (p, seed0) =>
       val f: (T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21,T22) => Z =
-        (t1: T1,t2: T2,t3: T3,t4: T4,t5: T5,t6: T6,t7: T7,t8: T8,t9: T9,t10: T10,t11: T11,t12: T12,t13: T13,t14: T14,t15: T15,t16: T16,t17: T17,t18: T18,t19: T19,t20: T20,t21: T21,t22: T22) => g.doApply(p, co22.perturb(co21.perturb(co20.perturb(co19.perturb(co18.perturb(co17.perturb(co16.perturb(co15.perturb(co14.perturb(co13.perturb(co12.perturb(co11.perturb(co10.perturb(co9.perturb(co8.perturb(co7.perturb(co6.perturb(co5.perturb(co4.perturb(co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3), t4), t5), t6), t7), t8), t9), t10), t11), t12), t13), t14), t15), t16), t17), t18), t19), t20), t21), t22)).retrieve.get
+        (t1: T1,t2: T2,t3: T3,t4: T4,t5: T5,t6: T6,t7: T7,t8: T8,t9: T9,t10: T10,t11: T11,t12: T12,t13: T13,t14: T14,t15: T15,t16: T16,t17: T17,t18: T18,t19: T19,t20: T20,t21: T21,t22: T22) => g.pureApply(p, co22.perturb(co21.perturb(co20.perturb(co19.perturb(co18.perturb(co17.perturb(co16.perturb(co15.perturb(co14.perturb(co13.perturb(co12.perturb(co11.perturb(co10.perturb(co9.perturb(co8.perturb(co7.perturb(co6.perturb(co5.perturb(co4.perturb(co3.perturb(co2.perturb(co1.perturb(seed0, t1), t2), t3), t4), t5), t6), t7), t8), t9), t10), t11), t12), t13), t14), t15), t16), t17), t18), t19), t20), t21), t22))
       new Gen.R[(T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21,T22) => Z] {
         val result = Some(f)
         val seed = seed0.next

--- a/tools/codegen.scala
+++ b/tools/codegen.scala
@@ -45,7 +45,7 @@ def genfn(i: Int) = s"""
   def function${i}[${types(i)},Z](g: Gen[Z])(implicit ${coImplicits(i)}): Gen[${fntype(i)}] =
     Gen.gen { (p, seed0) =>
       val f: ${fntype(i)} =
-        (${fnArgs(i)}) => g.doApply(p, ${nestedPerturbs(i)}).retrieve.get
+        (${fnArgs(i)}) => g.pureApply(p, ${nestedPerturbs(i)})
       new Gen.R[${fntype(i)}] {
         val result = Some(f)
         val seed = seed0.next


### PR DESCRIPTION
(This PR is a reworked version of #257. I also tried to reduce the
amount of code churn in this PR, even though there's a lot of code
that I'd like to see reformatted at some point.)

This PR was inspired by #218. It turns out that it ends up being
very easy to accidentally create empty generators (that will never
return Some(_) values) unnecessarily. The particular issue was around
usage of Gen.sized, but there are a number of other combinators that
end up creating empty generators in some cases.

Previously, when the arguments to a combinator make it impossible to
produce a value, ScalaCheck has preferred to produce empty Gen[T]
values. After this change, combinators whose arguments make it
impossible to generate values will instead throw exceptions during
creation. This makes it easier for the author to realize and correct
their mistake.

The PR also tightens up a bunch of the internal logic around
generating collections, numbers in a given range, etc. to minimize the
use of empty generators.

The reason why empty generators are a much bigger problem now than
before is the introduction of Cogen[T]. When we produce an arbitrary
A => B value, we do so by using a Cogen[A] to permute the PRNG,
and then use a Gen[B] to produce a B value from that PRNG
state. If our generator is empty (or even if it's a very sparse
partial generator), this process will fail when we try to apply the
function to an A value.

Since ScalaCheck allows empty generators (as QuickCheck does) there's
probably no backwards-compatible way to be 100% sure a Gen[B] is
safe to use. However, in practice most Gen instances could be safe
to use this way (as they are in QuickCheck), but are not due to how
easy it is to end up with empty (or mostly empty) generators.

This changes is binary compatible with the last release (check with
MiMA). It does introduce new runtime behavior (in the form of some new
exceptions users might see), but I think the change is worth it to get
faster (and safer) generators, as well as more reliable function
generators.

Review by @rickynils, @xuwei-k, and anyone else interested.