### PR TITLE
Topic/add extra cogens etc

### DIFF
--- a/src/main/scala/org/scalacheck/CogenArities.scala
+++ b/src/main/scala/org/scalacheck/CogenArities.scala
@@ -116,4 +116,395 @@ private[scalacheck] abstract class CogenArities{
     )
 
 
+  import Arbitrary.arbitrary
+  import Gen.Parameters.{ default => params }
+  import rng.Seed
+
+  
+  implicit final def function1[T1, Z](implicit a1:Arbitrary[T1], z: Cogen[Z]): Cogen[Function1[T1, Z]] =
+    Cogen { (seed: Seed, f: Function1[T1, Z]) =>
+      val r1 = arbitrary[T1].doPureApply(params, seed)
+
+      Cogen[Z].perturb(seed, f(r1.retrieve.get))
+    }
+
+  implicit final def function2[T1,T2, Z](implicit a1:Arbitrary[T1], a2:Arbitrary[T2], z: Cogen[Z]): Cogen[Function2[T1,T2, Z]] =
+    Cogen { (seed: Seed, f: Function2[T1,T2, Z]) =>
+      val r1 = arbitrary[T1].doPureApply(params, seed)
+      val r2 = arbitrary[T2].doPureApply(params, r1.seed)
+
+      Cogen[Z].perturb(seed, f(r1.retrieve.get, r2.retrieve.get))
+    }
+
+  implicit final def function3[T1,T2,T3, Z](implicit a1:Arbitrary[T1], a2:Arbitrary[T2], a3:Arbitrary[T3], z: Cogen[Z]): Cogen[Function3[T1,T2,T3, Z]] =
+    Cogen { (seed: Seed, f: Function3[T1,T2,T3, Z]) =>
+      val r1 = arbitrary[T1].doPureApply(params, seed)
+      val r2 = arbitrary[T2].doPureApply(params, r1.seed)
+      val r3 = arbitrary[T3].doPureApply(params, r2.seed)
+
+      Cogen[Z].perturb(seed, f(r1.retrieve.get, r2.retrieve.get, r3.retrieve.get))
+    }
+
+  implicit final def function4[T1,T2,T3,T4, Z](implicit a1:Arbitrary[T1], a2:Arbitrary[T2], a3:Arbitrary[T3], a4:Arbitrary[T4], z: Cogen[Z]): Cogen[Function4[T1,T2,T3,T4, Z]] =
+    Cogen { (seed: Seed, f: Function4[T1,T2,T3,T4, Z]) =>
+      val r1 = arbitrary[T1].doPureApply(params, seed)
+      val r2 = arbitrary[T2].doPureApply(params, r1.seed)
+      val r3 = arbitrary[T3].doPureApply(params, r2.seed)
+      val r4 = arbitrary[T4].doPureApply(params, r3.seed)
+
+      Cogen[Z].perturb(seed, f(r1.retrieve.get, r2.retrieve.get, r3.retrieve.get, r4.retrieve.get))
+    }
+
+  implicit final def function5[T1,T2,T3,T4,T5, Z](implicit a1:Arbitrary[T1], a2:Arbitrary[T2], a3:Arbitrary[T3], a4:Arbitrary[T4], a5:Arbitrary[T5], z: Cogen[Z]): Cogen[Function5[T1,T2,T3,T4,T5, Z]] =
+    Cogen { (seed: Seed, f: Function5[T1,T2,T3,T4,T5, Z]) =>
+      val r1 = arbitrary[T1].doPureApply(params, seed)
+      val r2 = arbitrary[T2].doPureApply(params, r1.seed)
+      val r3 = arbitrary[T3].doPureApply(params, r2.seed)
+      val r4 = arbitrary[T4].doPureApply(params, r3.seed)
+      val r5 = arbitrary[T5].doPureApply(params, r4.seed)
+
+      Cogen[Z].perturb(seed, f(r1.retrieve.get, r2.retrieve.get, r3.retrieve.get, r4.retrieve.get, r5.retrieve.get))
+    }
+
+  implicit final def function6[T1,T2,T3,T4,T5,T6, Z](implicit a1:Arbitrary[T1], a2:Arbitrary[T2], a3:Arbitrary[T3], a4:Arbitrary[T4], a5:Arbitrary[T5], a6:Arbitrary[T6], z: Cogen[Z]): Cogen[Function6[T1,T2,T3,T4,T5,T6, Z]] =
+    Cogen { (seed: Seed, f: Function6[T1,T2,T3,T4,T5,T6, Z]) =>
+      val r1 = arbitrary[T1].doPureApply(params, seed)
+      val r2 = arbitrary[T2].doPureApply(params, r1.seed)
+      val r3 = arbitrary[T3].doPureApply(params, r2.seed)
+      val r4 = arbitrary[T4].doPureApply(params, r3.seed)
+      val r5 = arbitrary[T5].doPureApply(params, r4.seed)
+      val r6 = arbitrary[T6].doPureApply(params, r5.seed)
+
+      Cogen[Z].perturb(seed, f(r1.retrieve.get, r2.retrieve.get, r3.retrieve.get, r4.retrieve.get, r5.retrieve.get, r6.retrieve.get))
+    }
+
+  implicit final def function7[T1,T2,T3,T4,T5,T6,T7, Z](implicit a1:Arbitrary[T1], a2:Arbitrary[T2], a3:Arbitrary[T3], a4:Arbitrary[T4], a5:Arbitrary[T5], a6:Arbitrary[T6], a7:Arbitrary[T7], z: Cogen[Z]): Cogen[Function7[T1,T2,T3,T4,T5,T6,T7, Z]] =
+    Cogen { (seed: Seed, f: Function7[T1,T2,T3,T4,T5,T6,T7, Z]) =>
+      val r1 = arbitrary[T1].doPureApply(params, seed)
+      val r2 = arbitrary[T2].doPureApply(params, r1.seed)
+      val r3 = arbitrary[T3].doPureApply(params, r2.seed)
+      val r4 = arbitrary[T4].doPureApply(params, r3.seed)
+      val r5 = arbitrary[T5].doPureApply(params, r4.seed)
+      val r6 = arbitrary[T6].doPureApply(params, r5.seed)
+      val r7 = arbitrary[T7].doPureApply(params, r6.seed)
+
+      Cogen[Z].perturb(seed, f(r1.retrieve.get, r2.retrieve.get, r3.retrieve.get, r4.retrieve.get, r5.retrieve.get, r6.retrieve.get, r7.retrieve.get))
+    }
+
+  implicit final def function8[T1,T2,T3,T4,T5,T6,T7,T8, Z](implicit a1:Arbitrary[T1], a2:Arbitrary[T2], a3:Arbitrary[T3], a4:Arbitrary[T4], a5:Arbitrary[T5], a6:Arbitrary[T6], a7:Arbitrary[T7], a8:Arbitrary[T8], z: Cogen[Z]): Cogen[Function8[T1,T2,T3,T4,T5,T6,T7,T8, Z]] =
+    Cogen { (seed: Seed, f: Function8[T1,T2,T3,T4,T5,T6,T7,T8, Z]) =>
+      val r1 = arbitrary[T1].doPureApply(params, seed)
+      val r2 = arbitrary[T2].doPureApply(params, r1.seed)
+      val r3 = arbitrary[T3].doPureApply(params, r2.seed)
+      val r4 = arbitrary[T4].doPureApply(params, r3.seed)
+      val r5 = arbitrary[T5].doPureApply(params, r4.seed)
+      val r6 = arbitrary[T6].doPureApply(params, r5.seed)
+      val r7 = arbitrary[T7].doPureApply(params, r6.seed)
+      val r8 = arbitrary[T8].doPureApply(params, r7.seed)
+
+      Cogen[Z].perturb(seed, f(r1.retrieve.get, r2.retrieve.get, r3.retrieve.get, r4.retrieve.get, r5.retrieve.get, r6.retrieve.get, r7.retrieve.get, r8.retrieve.get))
+    }
+
+  implicit final def function9[T1,T2,T3,T4,T5,T6,T7,T8,T9, Z](implicit a1:Arbitrary[T1], a2:Arbitrary[T2], a3:Arbitrary[T3], a4:Arbitrary[T4], a5:Arbitrary[T5], a6:Arbitrary[T6], a7:Arbitrary[T7], a8:Arbitrary[T8], a9:Arbitrary[T9], z: Cogen[Z]): Cogen[Function9[T1,T2,T3,T4,T5,T6,T7,T8,T9, Z]] =
+    Cogen { (seed: Seed, f: Function9[T1,T2,T3,T4,T5,T6,T7,T8,T9, Z]) =>
+      val r1 = arbitrary[T1].doPureApply(params, seed)
+      val r2 = arbitrary[T2].doPureApply(params, r1.seed)
+      val r3 = arbitrary[T3].doPureApply(params, r2.seed)
+      val r4 = arbitrary[T4].doPureApply(params, r3.seed)
+      val r5 = arbitrary[T5].doPureApply(params, r4.seed)
+      val r6 = arbitrary[T6].doPureApply(params, r5.seed)
+      val r7 = arbitrary[T7].doPureApply(params, r6.seed)
+      val r8 = arbitrary[T8].doPureApply(params, r7.seed)
+      val r9 = arbitrary[T9].doPureApply(params, r8.seed)
+
+      Cogen[Z].perturb(seed, f(r1.retrieve.get, r2.retrieve.get, r3.retrieve.get, r4.retrieve.get, r5.retrieve.get, r6.retrieve.get, r7.retrieve.get, r8.retrieve.get, r9.retrieve.get))
+    }
+
+  implicit final def function10[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10, Z](implicit a1:Arbitrary[T1], a2:Arbitrary[T2], a3:Arbitrary[T3], a4:Arbitrary[T4], a5:Arbitrary[T5], a6:Arbitrary[T6], a7:Arbitrary[T7], a8:Arbitrary[T8], a9:Arbitrary[T9], a10:Arbitrary[T10], z: Cogen[Z]): Cogen[Function10[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10, Z]] =
+    Cogen { (seed: Seed, f: Function10[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10, Z]) =>
+      val r1 = arbitrary[T1].doPureApply(params, seed)
+      val r2 = arbitrary[T2].doPureApply(params, r1.seed)
+      val r3 = arbitrary[T3].doPureApply(params, r2.seed)
+      val r4 = arbitrary[T4].doPureApply(params, r3.seed)
+      val r5 = arbitrary[T5].doPureApply(params, r4.seed)
+      val r6 = arbitrary[T6].doPureApply(params, r5.seed)
+      val r7 = arbitrary[T7].doPureApply(params, r6.seed)
+      val r8 = arbitrary[T8].doPureApply(params, r7.seed)
+      val r9 = arbitrary[T9].doPureApply(params, r8.seed)
+      val r10 = arbitrary[T10].doPureApply(params, r9.seed)
+
+      Cogen[Z].perturb(seed, f(r1.retrieve.get, r2.retrieve.get, r3.retrieve.get, r4.retrieve.get, r5.retrieve.get, r6.retrieve.get, r7.retrieve.get, r8.retrieve.get, r9.retrieve.get, r10.retrieve.get))
+    }
+
+  implicit final def function11[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11, Z](implicit a1:Arbitrary[T1], a2:Arbitrary[T2], a3:Arbitrary[T3], a4:Arbitrary[T4], a5:Arbitrary[T5], a6:Arbitrary[T6], a7:Arbitrary[T7], a8:Arbitrary[T8], a9:Arbitrary[T9], a10:Arbitrary[T10], a11:Arbitrary[T11], z: Cogen[Z]): Cogen[Function11[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11, Z]] =
+    Cogen { (seed: Seed, f: Function11[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11, Z]) =>
+      val r1 = arbitrary[T1].doPureApply(params, seed)
+      val r2 = arbitrary[T2].doPureApply(params, r1.seed)
+      val r3 = arbitrary[T3].doPureApply(params, r2.seed)
+      val r4 = arbitrary[T4].doPureApply(params, r3.seed)
+      val r5 = arbitrary[T5].doPureApply(params, r4.seed)
+      val r6 = arbitrary[T6].doPureApply(params, r5.seed)
+      val r7 = arbitrary[T7].doPureApply(params, r6.seed)
+      val r8 = arbitrary[T8].doPureApply(params, r7.seed)
+      val r9 = arbitrary[T9].doPureApply(params, r8.seed)
+      val r10 = arbitrary[T10].doPureApply(params, r9.seed)
+      val r11 = arbitrary[T11].doPureApply(params, r10.seed)
+
+      Cogen[Z].perturb(seed, f(r1.retrieve.get, r2.retrieve.get, r3.retrieve.get, r4.retrieve.get, r5.retrieve.get, r6.retrieve.get, r7.retrieve.get, r8.retrieve.get, r9.retrieve.get, r10.retrieve.get, r11.retrieve.get))
+    }
+
+  implicit final def function12[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12, Z](implicit a1:Arbitrary[T1], a2:Arbitrary[T2], a3:Arbitrary[T3], a4:Arbitrary[T4], a5:Arbitrary[T5], a6:Arbitrary[T6], a7:Arbitrary[T7], a8:Arbitrary[T8], a9:Arbitrary[T9], a10:Arbitrary[T10], a11:Arbitrary[T11], a12:Arbitrary[T12], z: Cogen[Z]): Cogen[Function12[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12, Z]] =
+    Cogen { (seed: Seed, f: Function12[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12, Z]) =>
+      val r1 = arbitrary[T1].doPureApply(params, seed)
+      val r2 = arbitrary[T2].doPureApply(params, r1.seed)
+      val r3 = arbitrary[T3].doPureApply(params, r2.seed)
+      val r4 = arbitrary[T4].doPureApply(params, r3.seed)
+      val r5 = arbitrary[T5].doPureApply(params, r4.seed)
+      val r6 = arbitrary[T6].doPureApply(params, r5.seed)
+      val r7 = arbitrary[T7].doPureApply(params, r6.seed)
+      val r8 = arbitrary[T8].doPureApply(params, r7.seed)
+      val r9 = arbitrary[T9].doPureApply(params, r8.seed)
+      val r10 = arbitrary[T10].doPureApply(params, r9.seed)
+      val r11 = arbitrary[T11].doPureApply(params, r10.seed)
+      val r12 = arbitrary[T12].doPureApply(params, r11.seed)
+
+      Cogen[Z].perturb(seed, f(r1.retrieve.get, r2.retrieve.get, r3.retrieve.get, r4.retrieve.get, r5.retrieve.get, r6.retrieve.get, r7.retrieve.get, r8.retrieve.get, r9.retrieve.get, r10.retrieve.get, r11.retrieve.get, r12.retrieve.get))
+    }
+
+  implicit final def function13[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13, Z](implicit a1:Arbitrary[T1], a2:Arbitrary[T2], a3:Arbitrary[T3], a4:Arbitrary[T4], a5:Arbitrary[T5], a6:Arbitrary[T6], a7:Arbitrary[T7], a8:Arbitrary[T8], a9:Arbitrary[T9], a10:Arbitrary[T10], a11:Arbitrary[T11], a12:Arbitrary[T12], a13:Arbitrary[T13], z: Cogen[Z]): Cogen[Function13[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13, Z]] =
+    Cogen { (seed: Seed, f: Function13[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13, Z]) =>
+      val r1 = arbitrary[T1].doPureApply(params, seed)
+      val r2 = arbitrary[T2].doPureApply(params, r1.seed)
+      val r3 = arbitrary[T3].doPureApply(params, r2.seed)
+      val r4 = arbitrary[T4].doPureApply(params, r3.seed)
+      val r5 = arbitrary[T5].doPureApply(params, r4.seed)
+      val r6 = arbitrary[T6].doPureApply(params, r5.seed)
+      val r7 = arbitrary[T7].doPureApply(params, r6.seed)
+      val r8 = arbitrary[T8].doPureApply(params, r7.seed)
+      val r9 = arbitrary[T9].doPureApply(params, r8.seed)
+      val r10 = arbitrary[T10].doPureApply(params, r9.seed)
+      val r11 = arbitrary[T11].doPureApply(params, r10.seed)
+      val r12 = arbitrary[T12].doPureApply(params, r11.seed)
+      val r13 = arbitrary[T13].doPureApply(params, r12.seed)
+
+      Cogen[Z].perturb(seed, f(r1.retrieve.get, r2.retrieve.get, r3.retrieve.get, r4.retrieve.get, r5.retrieve.get, r6.retrieve.get, r7.retrieve.get, r8.retrieve.get, r9.retrieve.get, r10.retrieve.get, r11.retrieve.get, r12.retrieve.get, r13.retrieve.get))
+    }
+
+  implicit final def function14[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14, Z](implicit a1:Arbitrary[T1], a2:Arbitrary[T2], a3:Arbitrary[T3], a4:Arbitrary[T4], a5:Arbitrary[T5], a6:Arbitrary[T6], a7:Arbitrary[T7], a8:Arbitrary[T8], a9:Arbitrary[T9], a10:Arbitrary[T10], a11:Arbitrary[T11], a12:Arbitrary[T12], a13:Arbitrary[T13], a14:Arbitrary[T14], z: Cogen[Z]): Cogen[Function14[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14, Z]] =
+    Cogen { (seed: Seed, f: Function14[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14, Z]) =>
+      val r1 = arbitrary[T1].doPureApply(params, seed)
+      val r2 = arbitrary[T2].doPureApply(params, r1.seed)
+      val r3 = arbitrary[T3].doPureApply(params, r2.seed)
+      val r4 = arbitrary[T4].doPureApply(params, r3.seed)
+      val r5 = arbitrary[T5].doPureApply(params, r4.seed)
+      val r6 = arbitrary[T6].doPureApply(params, r5.seed)
+      val r7 = arbitrary[T7].doPureApply(params, r6.seed)
+      val r8 = arbitrary[T8].doPureApply(params, r7.seed)
+      val r9 = arbitrary[T9].doPureApply(params, r8.seed)
+      val r10 = arbitrary[T10].doPureApply(params, r9.seed)
+      val r11 = arbitrary[T11].doPureApply(params, r10.seed)
+      val r12 = arbitrary[T12].doPureApply(params, r11.seed)
+      val r13 = arbitrary[T13].doPureApply(params, r12.seed)
+      val r14 = arbitrary[T14].doPureApply(params, r13.seed)
+
+      Cogen[Z].perturb(seed, f(r1.retrieve.get, r2.retrieve.get, r3.retrieve.get, r4.retrieve.get, r5.retrieve.get, r6.retrieve.get, r7.retrieve.get, r8.retrieve.get, r9.retrieve.get, r10.retrieve.get, r11.retrieve.get, r12.retrieve.get, r13.retrieve.get, r14.retrieve.get))
+    }
+
+  implicit final def function15[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15, Z](implicit a1:Arbitrary[T1], a2:Arbitrary[T2], a3:Arbitrary[T3], a4:Arbitrary[T4], a5:Arbitrary[T5], a6:Arbitrary[T6], a7:Arbitrary[T7], a8:Arbitrary[T8], a9:Arbitrary[T9], a10:Arbitrary[T10], a11:Arbitrary[T11], a12:Arbitrary[T12], a13:Arbitrary[T13], a14:Arbitrary[T14], a15:Arbitrary[T15], z: Cogen[Z]): Cogen[Function15[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15, Z]] =
+    Cogen { (seed: Seed, f: Function15[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15, Z]) =>
+      val r1 = arbitrary[T1].doPureApply(params, seed)
+      val r2 = arbitrary[T2].doPureApply(params, r1.seed)
+      val r3 = arbitrary[T3].doPureApply(params, r2.seed)
+      val r4 = arbitrary[T4].doPureApply(params, r3.seed)
+      val r5 = arbitrary[T5].doPureApply(params, r4.seed)
+      val r6 = arbitrary[T6].doPureApply(params, r5.seed)
+      val r7 = arbitrary[T7].doPureApply(params, r6.seed)
+      val r8 = arbitrary[T8].doPureApply(params, r7.seed)
+      val r9 = arbitrary[T9].doPureApply(params, r8.seed)
+      val r10 = arbitrary[T10].doPureApply(params, r9.seed)
+      val r11 = arbitrary[T11].doPureApply(params, r10.seed)
+      val r12 = arbitrary[T12].doPureApply(params, r11.seed)
+      val r13 = arbitrary[T13].doPureApply(params, r12.seed)
+      val r14 = arbitrary[T14].doPureApply(params, r13.seed)
+      val r15 = arbitrary[T15].doPureApply(params, r14.seed)
+
+      Cogen[Z].perturb(seed, f(r1.retrieve.get, r2.retrieve.get, r3.retrieve.get, r4.retrieve.get, r5.retrieve.get, r6.retrieve.get, r7.retrieve.get, r8.retrieve.get, r9.retrieve.get, r10.retrieve.get, r11.retrieve.get, r12.retrieve.get, r13.retrieve.get, r14.retrieve.get, r15.retrieve.get))
+    }
+
+  implicit final def function16[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16, Z](implicit a1:Arbitrary[T1], a2:Arbitrary[T2], a3:Arbitrary[T3], a4:Arbitrary[T4], a5:Arbitrary[T5], a6:Arbitrary[T6], a7:Arbitrary[T7], a8:Arbitrary[T8], a9:Arbitrary[T9], a10:Arbitrary[T10], a11:Arbitrary[T11], a12:Arbitrary[T12], a13:Arbitrary[T13], a14:Arbitrary[T14], a15:Arbitrary[T15], a16:Arbitrary[T16], z: Cogen[Z]): Cogen[Function16[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16, Z]] =
+    Cogen { (seed: Seed, f: Function16[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16, Z]) =>
+      val r1 = arbitrary[T1].doPureApply(params, seed)
+      val r2 = arbitrary[T2].doPureApply(params, r1.seed)
+      val r3 = arbitrary[T3].doPureApply(params, r2.seed)
+      val r4 = arbitrary[T4].doPureApply(params, r3.seed)
+      val r5 = arbitrary[T5].doPureApply(params, r4.seed)
+      val r6 = arbitrary[T6].doPureApply(params, r5.seed)
+      val r7 = arbitrary[T7].doPureApply(params, r6.seed)
+      val r8 = arbitrary[T8].doPureApply(params, r7.seed)
+      val r9 = arbitrary[T9].doPureApply(params, r8.seed)
+      val r10 = arbitrary[T10].doPureApply(params, r9.seed)
+      val r11 = arbitrary[T11].doPureApply(params, r10.seed)
+      val r12 = arbitrary[T12].doPureApply(params, r11.seed)
+      val r13 = arbitrary[T13].doPureApply(params, r12.seed)
+      val r14 = arbitrary[T14].doPureApply(params, r13.seed)
+      val r15 = arbitrary[T15].doPureApply(params, r14.seed)
+      val r16 = arbitrary[T16].doPureApply(params, r15.seed)
+
+      Cogen[Z].perturb(seed, f(r1.retrieve.get, r2.retrieve.get, r3.retrieve.get, r4.retrieve.get, r5.retrieve.get, r6.retrieve.get, r7.retrieve.get, r8.retrieve.get, r9.retrieve.get, r10.retrieve.get, r11.retrieve.get, r12.retrieve.get, r13.retrieve.get, r14.retrieve.get, r15.retrieve.get, r16.retrieve.get))
+    }
+
+  implicit final def function17[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17, Z](implicit a1:Arbitrary[T1], a2:Arbitrary[T2], a3:Arbitrary[T3], a4:Arbitrary[T4], a5:Arbitrary[T5], a6:Arbitrary[T6], a7:Arbitrary[T7], a8:Arbitrary[T8], a9:Arbitrary[T9], a10:Arbitrary[T10], a11:Arbitrary[T11], a12:Arbitrary[T12], a13:Arbitrary[T13], a14:Arbitrary[T14], a15:Arbitrary[T15], a16:Arbitrary[T16], a17:Arbitrary[T17], z: Cogen[Z]): Cogen[Function17[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17, Z]] =
+    Cogen { (seed: Seed, f: Function17[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17, Z]) =>
+      val r1 = arbitrary[T1].doPureApply(params, seed)
+      val r2 = arbitrary[T2].doPureApply(params, r1.seed)
+      val r3 = arbitrary[T3].doPureApply(params, r2.seed)
+      val r4 = arbitrary[T4].doPureApply(params, r3.seed)
+      val r5 = arbitrary[T5].doPureApply(params, r4.seed)
+      val r6 = arbitrary[T6].doPureApply(params, r5.seed)
+      val r7 = arbitrary[T7].doPureApply(params, r6.seed)
+      val r8 = arbitrary[T8].doPureApply(params, r7.seed)
+      val r9 = arbitrary[T9].doPureApply(params, r8.seed)
+      val r10 = arbitrary[T10].doPureApply(params, r9.seed)
+      val r11 = arbitrary[T11].doPureApply(params, r10.seed)
+      val r12 = arbitrary[T12].doPureApply(params, r11.seed)
+      val r13 = arbitrary[T13].doPureApply(params, r12.seed)
+      val r14 = arbitrary[T14].doPureApply(params, r13.seed)
+      val r15 = arbitrary[T15].doPureApply(params, r14.seed)
+      val r16 = arbitrary[T16].doPureApply(params, r15.seed)
+      val r17 = arbitrary[T17].doPureApply(params, r16.seed)
+
+      Cogen[Z].perturb(seed, f(r1.retrieve.get, r2.retrieve.get, r3.retrieve.get, r4.retrieve.get, r5.retrieve.get, r6.retrieve.get, r7.retrieve.get, r8.retrieve.get, r9.retrieve.get, r10.retrieve.get, r11.retrieve.get, r12.retrieve.get, r13.retrieve.get, r14.retrieve.get, r15.retrieve.get, r16.retrieve.get, r17.retrieve.get))
+    }
+
+  implicit final def function18[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18, Z](implicit a1:Arbitrary[T1], a2:Arbitrary[T2], a3:Arbitrary[T3], a4:Arbitrary[T4], a5:Arbitrary[T5], a6:Arbitrary[T6], a7:Arbitrary[T7], a8:Arbitrary[T8], a9:Arbitrary[T9], a10:Arbitrary[T10], a11:Arbitrary[T11], a12:Arbitrary[T12], a13:Arbitrary[T13], a14:Arbitrary[T14], a15:Arbitrary[T15], a16:Arbitrary[T16], a17:Arbitrary[T17], a18:Arbitrary[T18], z: Cogen[Z]): Cogen[Function18[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18, Z]] =
+    Cogen { (seed: Seed, f: Function18[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18, Z]) =>
+      val r1 = arbitrary[T1].doPureApply(params, seed)
+      val r2 = arbitrary[T2].doPureApply(params, r1.seed)
+      val r3 = arbitrary[T3].doPureApply(params, r2.seed)
+      val r4 = arbitrary[T4].doPureApply(params, r3.seed)
+      val r5 = arbitrary[T5].doPureApply(params, r4.seed)
+      val r6 = arbitrary[T6].doPureApply(params, r5.seed)
+      val r7 = arbitrary[T7].doPureApply(params, r6.seed)
+      val r8 = arbitrary[T8].doPureApply(params, r7.seed)
+      val r9 = arbitrary[T9].doPureApply(params, r8.seed)
+      val r10 = arbitrary[T10].doPureApply(params, r9.seed)
+      val r11 = arbitrary[T11].doPureApply(params, r10.seed)
+      val r12 = arbitrary[T12].doPureApply(params, r11.seed)
+      val r13 = arbitrary[T13].doPureApply(params, r12.seed)
+      val r14 = arbitrary[T14].doPureApply(params, r13.seed)
+      val r15 = arbitrary[T15].doPureApply(params, r14.seed)
+      val r16 = arbitrary[T16].doPureApply(params, r15.seed)
+      val r17 = arbitrary[T17].doPureApply(params, r16.seed)
+      val r18 = arbitrary[T18].doPureApply(params, r17.seed)
+
+      Cogen[Z].perturb(seed, f(r1.retrieve.get, r2.retrieve.get, r3.retrieve.get, r4.retrieve.get, r5.retrieve.get, r6.retrieve.get, r7.retrieve.get, r8.retrieve.get, r9.retrieve.get, r10.retrieve.get, r11.retrieve.get, r12.retrieve.get, r13.retrieve.get, r14.retrieve.get, r15.retrieve.get, r16.retrieve.get, r17.retrieve.get, r18.retrieve.get))
+    }
+
+  implicit final def function19[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19, Z](implicit a1:Arbitrary[T1], a2:Arbitrary[T2], a3:Arbitrary[T3], a4:Arbitrary[T4], a5:Arbitrary[T5], a6:Arbitrary[T6], a7:Arbitrary[T7], a8:Arbitrary[T8], a9:Arbitrary[T9], a10:Arbitrary[T10], a11:Arbitrary[T11], a12:Arbitrary[T12], a13:Arbitrary[T13], a14:Arbitrary[T14], a15:Arbitrary[T15], a16:Arbitrary[T16], a17:Arbitrary[T17], a18:Arbitrary[T18], a19:Arbitrary[T19], z: Cogen[Z]): Cogen[Function19[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19, Z]] =
+    Cogen { (seed: Seed, f: Function19[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19, Z]) =>
+      val r1 = arbitrary[T1].doPureApply(params, seed)
+      val r2 = arbitrary[T2].doPureApply(params, r1.seed)
+      val r3 = arbitrary[T3].doPureApply(params, r2.seed)
+      val r4 = arbitrary[T4].doPureApply(params, r3.seed)
+      val r5 = arbitrary[T5].doPureApply(params, r4.seed)
+      val r6 = arbitrary[T6].doPureApply(params, r5.seed)
+      val r7 = arbitrary[T7].doPureApply(params, r6.seed)
+      val r8 = arbitrary[T8].doPureApply(params, r7.seed)
+      val r9 = arbitrary[T9].doPureApply(params, r8.seed)
+      val r10 = arbitrary[T10].doPureApply(params, r9.seed)
+      val r11 = arbitrary[T11].doPureApply(params, r10.seed)
+      val r12 = arbitrary[T12].doPureApply(params, r11.seed)
+      val r13 = arbitrary[T13].doPureApply(params, r12.seed)
+      val r14 = arbitrary[T14].doPureApply(params, r13.seed)
+      val r15 = arbitrary[T15].doPureApply(params, r14.seed)
+      val r16 = arbitrary[T16].doPureApply(params, r15.seed)
+      val r17 = arbitrary[T17].doPureApply(params, r16.seed)
+      val r18 = arbitrary[T18].doPureApply(params, r17.seed)
+      val r19 = arbitrary[T19].doPureApply(params, r18.seed)
+
+      Cogen[Z].perturb(seed, f(r1.retrieve.get, r2.retrieve.get, r3.retrieve.get, r4.retrieve.get, r5.retrieve.get, r6.retrieve.get, r7.retrieve.get, r8.retrieve.get, r9.retrieve.get, r10.retrieve.get, r11.retrieve.get, r12.retrieve.get, r13.retrieve.get, r14.retrieve.get, r15.retrieve.get, r16.retrieve.get, r17.retrieve.get, r18.retrieve.get, r19.retrieve.get))
+    }
+
+  implicit final def function20[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20, Z](implicit a1:Arbitrary[T1], a2:Arbitrary[T2], a3:Arbitrary[T3], a4:Arbitrary[T4], a5:Arbitrary[T5], a6:Arbitrary[T6], a7:Arbitrary[T7], a8:Arbitrary[T8], a9:Arbitrary[T9], a10:Arbitrary[T10], a11:Arbitrary[T11], a12:Arbitrary[T12], a13:Arbitrary[T13], a14:Arbitrary[T14], a15:Arbitrary[T15], a16:Arbitrary[T16], a17:Arbitrary[T17], a18:Arbitrary[T18], a19:Arbitrary[T19], a20:Arbitrary[T20], z: Cogen[Z]): Cogen[Function20[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20, Z]] =
+    Cogen { (seed: Seed, f: Function20[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20, Z]) =>
+      val r1 = arbitrary[T1].doPureApply(params, seed)
+      val r2 = arbitrary[T2].doPureApply(params, r1.seed)
+      val r3 = arbitrary[T3].doPureApply(params, r2.seed)
+      val r4 = arbitrary[T4].doPureApply(params, r3.seed)
+      val r5 = arbitrary[T5].doPureApply(params, r4.seed)
+      val r6 = arbitrary[T6].doPureApply(params, r5.seed)
+      val r7 = arbitrary[T7].doPureApply(params, r6.seed)
+      val r8 = arbitrary[T8].doPureApply(params, r7.seed)
+      val r9 = arbitrary[T9].doPureApply(params, r8.seed)
+      val r10 = arbitrary[T10].doPureApply(params, r9.seed)
+      val r11 = arbitrary[T11].doPureApply(params, r10.seed)
+      val r12 = arbitrary[T12].doPureApply(params, r11.seed)
+      val r13 = arbitrary[T13].doPureApply(params, r12.seed)
+      val r14 = arbitrary[T14].doPureApply(params, r13.seed)
+      val r15 = arbitrary[T15].doPureApply(params, r14.seed)
+      val r16 = arbitrary[T16].doPureApply(params, r15.seed)
+      val r17 = arbitrary[T17].doPureApply(params, r16.seed)
+      val r18 = arbitrary[T18].doPureApply(params, r17.seed)
+      val r19 = arbitrary[T19].doPureApply(params, r18.seed)
+      val r20 = arbitrary[T20].doPureApply(params, r19.seed)
+
+      Cogen[Z].perturb(seed, f(r1.retrieve.get, r2.retrieve.get, r3.retrieve.get, r4.retrieve.get, r5.retrieve.get, r6.retrieve.get, r7.retrieve.get, r8.retrieve.get, r9.retrieve.get, r10.retrieve.get, r11.retrieve.get, r12.retrieve.get, r13.retrieve.get, r14.retrieve.get, r15.retrieve.get, r16.retrieve.get, r17.retrieve.get, r18.retrieve.get, r19.retrieve.get, r20.retrieve.get))
+    }
+
+  implicit final def function21[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21, Z](implicit a1:Arbitrary[T1], a2:Arbitrary[T2], a3:Arbitrary[T3], a4:Arbitrary[T4], a5:Arbitrary[T5], a6:Arbitrary[T6], a7:Arbitrary[T7], a8:Arbitrary[T8], a9:Arbitrary[T9], a10:Arbitrary[T10], a11:Arbitrary[T11], a12:Arbitrary[T12], a13:Arbitrary[T13], a14:Arbitrary[T14], a15:Arbitrary[T15], a16:Arbitrary[T16], a17:Arbitrary[T17], a18:Arbitrary[T18], a19:Arbitrary[T19], a20:Arbitrary[T20], a21:Arbitrary[T21], z: Cogen[Z]): Cogen[Function21[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21, Z]] =
+    Cogen { (seed: Seed, f: Function21[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21, Z]) =>
+      val r1 = arbitrary[T1].doPureApply(params, seed)
+      val r2 = arbitrary[T2].doPureApply(params, r1.seed)
+      val r3 = arbitrary[T3].doPureApply(params, r2.seed)
+      val r4 = arbitrary[T4].doPureApply(params, r3.seed)
+      val r5 = arbitrary[T5].doPureApply(params, r4.seed)
+      val r6 = arbitrary[T6].doPureApply(params, r5.seed)
+      val r7 = arbitrary[T7].doPureApply(params, r6.seed)
+      val r8 = arbitrary[T8].doPureApply(params, r7.seed)
+      val r9 = arbitrary[T9].doPureApply(params, r8.seed)
+      val r10 = arbitrary[T10].doPureApply(params, r9.seed)
+      val r11 = arbitrary[T11].doPureApply(params, r10.seed)
+      val r12 = arbitrary[T12].doPureApply(params, r11.seed)
+      val r13 = arbitrary[T13].doPureApply(params, r12.seed)
+      val r14 = arbitrary[T14].doPureApply(params, r13.seed)
+      val r15 = arbitrary[T15].doPureApply(params, r14.seed)
+      val r16 = arbitrary[T16].doPureApply(params, r15.seed)
+      val r17 = arbitrary[T17].doPureApply(params, r16.seed)
+      val r18 = arbitrary[T18].doPureApply(params, r17.seed)
+      val r19 = arbitrary[T19].doPureApply(params, r18.seed)
+      val r20 = arbitrary[T20].doPureApply(params, r19.seed)
+      val r21 = arbitrary[T21].doPureApply(params, r20.seed)
+
+      Cogen[Z].perturb(seed, f(r1.retrieve.get, r2.retrieve.get, r3.retrieve.get, r4.retrieve.get, r5.retrieve.get, r6.retrieve.get, r7.retrieve.get, r8.retrieve.get, r9.retrieve.get, r10.retrieve.get, r11.retrieve.get, r12.retrieve.get, r13.retrieve.get, r14.retrieve.get, r15.retrieve.get, r16.retrieve.get, r17.retrieve.get, r18.retrieve.get, r19.retrieve.get, r20.retrieve.get, r21.retrieve.get))
+    }
+
+  implicit final def function22[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21,T22, Z](implicit a1:Arbitrary[T1], a2:Arbitrary[T2], a3:Arbitrary[T3], a4:Arbitrary[T4], a5:Arbitrary[T5], a6:Arbitrary[T6], a7:Arbitrary[T7], a8:Arbitrary[T8], a9:Arbitrary[T9], a10:Arbitrary[T10], a11:Arbitrary[T11], a12:Arbitrary[T12], a13:Arbitrary[T13], a14:Arbitrary[T14], a15:Arbitrary[T15], a16:Arbitrary[T16], a17:Arbitrary[T17], a18:Arbitrary[T18], a19:Arbitrary[T19], a20:Arbitrary[T20], a21:Arbitrary[T21], a22:Arbitrary[T22], z: Cogen[Z]): Cogen[Function22[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21,T22, Z]] =
+    Cogen { (seed: Seed, f: Function22[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21,T22, Z]) =>
+      val r1 = arbitrary[T1].doPureApply(params, seed)
+      val r2 = arbitrary[T2].doPureApply(params, r1.seed)
+      val r3 = arbitrary[T3].doPureApply(params, r2.seed)
+      val r4 = arbitrary[T4].doPureApply(params, r3.seed)
+      val r5 = arbitrary[T5].doPureApply(params, r4.seed)
+      val r6 = arbitrary[T6].doPureApply(params, r5.seed)
+      val r7 = arbitrary[T7].doPureApply(params, r6.seed)
+      val r8 = arbitrary[T8].doPureApply(params, r7.seed)
+      val r9 = arbitrary[T9].doPureApply(params, r8.seed)
+      val r10 = arbitrary[T10].doPureApply(params, r9.seed)
+      val r11 = arbitrary[T11].doPureApply(params, r10.seed)
+      val r12 = arbitrary[T12].doPureApply(params, r11.seed)
+      val r13 = arbitrary[T13].doPureApply(params, r12.seed)
+      val r14 = arbitrary[T14].doPureApply(params, r13.seed)
+      val r15 = arbitrary[T15].doPureApply(params, r14.seed)
+      val r16 = arbitrary[T16].doPureApply(params, r15.seed)
+      val r17 = arbitrary[T17].doPureApply(params, r16.seed)
+      val r18 = arbitrary[T18].doPureApply(params, r17.seed)
+      val r19 = arbitrary[T19].doPureApply(params, r18.seed)
+      val r20 = arbitrary[T20].doPureApply(params, r19.seed)
+      val r21 = arbitrary[T21].doPureApply(params, r20.seed)
+      val r22 = arbitrary[T22].doPureApply(params, r21.seed)
+
+      Cogen[Z].perturb(seed, f(r1.retrieve.get, r2.retrieve.get, r3.retrieve.get, r4.retrieve.get, r5.retrieve.get, r6.retrieve.get, r7.retrieve.get, r8.retrieve.get, r9.retrieve.get, r10.retrieve.get, r11.retrieve.get, r12.retrieve.get, r13.retrieve.get, r14.retrieve.get, r15.retrieve.get, r16.retrieve.get, r17.retrieve.get, r18.retrieve.get, r19.retrieve.get, r20.retrieve.get, r21.retrieve.get, r22.retrieve.get))
+    }
+
+
 }


### PR DESCRIPTION
This PR adds `Cogen` instances for:

 - `BigInt`
 - `BigDecimal`
 - `BitSet`
 - `Seq[T]` (low-priority)
 - `Function0`
 - `Function1`-`Function22`
 - `Exception` (using `.toString`)
 - `Throwable` (using `.toString`)
 - `Try[A]`

These seems to cover most of the non-date, non-scalacheck types that we have
`Arbitrary` instances for.

This PR depends on #258 -- we should merge that first.

Fixes #226 and #190.