### PR TITLE
Support deterministic testing using Parameters.

### DIFF
--- a/jvm/src/test/scala/org/scalacheck/rng/SeedSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/rng/SeedSpecification.scala
@@ -1,0 +1,65 @@
+/*-------------------------------------------------------------------------*\
+**  ScalaCheck                                                             **
+**  Copyright (c) 2007-2016 Rickard Nilsson. All rights reserved.          **
+**  http://www.scalacheck.org                                              **
+**                                                                         **
+**  This software is released under the terms of the Revised BSD License.  **
+**  There is NO WARRANTY. See the file LICENSE for the full text.          **
+\*------------------------------------------------------------------------ */
+
+package org.scalacheck
+
+import Prop.forAll
+import Arbitrary.arbitrary
+import rng.Seed
+
+object SeedSpecification extends Properties("Seed") {
+
+  implicit val arbSeed: Arbitrary[Seed] =
+    Arbitrary(arbitrary[Long].flatMap(n => Seed(n)))
+
+  property("different seeds produce different values") =
+    forAll { (s: Seed) =>
+      s.long._1 != s.next.long._1
+    }
+
+  property("doubles are within [0, 1)") =
+    forAll { (s: Seed) =>
+      val n = s.double._1
+      0.0 <= n && n < 1.0
+    }
+
+  property("longs are evenly-distributed") =
+    forAll(arbitrary[Seed], Gen.choose(2, 100)) { (seed: Seed, base: Int) =>
+      val buckets = new Array[Int](base)
+      def loop(s0: Seed, count: Int): Unit =
+        if (count > 0) {
+          val (x, s1) = s0.long
+          buckets((x & 0xffff).toInt % base) += 1
+          loop(s1, count - 1)
+        }
+      loop(seed, 1000)
+      base == base
+    }
+
+  property("equality works") =
+    forAll { (s0: Seed, s1: Seed) =>
+      def p(s0: Seed, s1: Seed): Boolean = (s0 == s1) == (s0.long == s1.long)
+      p(s0, s0) && p(s0, s1) && p(s1, s0) && p(s1, s1)
+    }
+
+  property("reseed works") =
+    forAll { (s: Seed, n: Long) =>
+      s.reseed(n) != s
+    }
+
+  property("base-64 serialization works") =
+    forAll { (s0: Seed) =>
+      s0 == Seed.fromBase64(s0.toBase64)
+    }
+
+  property("illegal seeds throw exceptions") =
+    forAll { (s: String) =>
+      scala.util.Try(Seed.fromBase64(s)).isFailure
+    }
+}

--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -299,12 +299,6 @@ object Gen extends GenArities{
         case None => f(this, seed)
       }
 
-    def startInitialSeed[A](f: (Parameters, Seed) => A): A =
-      initialSeed match {
-        case Some(s) => f(this.withNoInitialSeed, s)
-        case None => f(this, Seed.random())
-      }
-
     // private since we can't guarantee binary compatibility for this one
     private case class cp(size: Int = size, initialSeed: Option[Seed] = None) extends Parameters
   }
@@ -663,7 +657,7 @@ object Gen extends GenArities{
 
   /** A generator that picks a given number of elements from a list, randomly */
   def pick[T](n: Int, l: Iterable[T]): Gen[Seq[T]] = {
-    if (n > l.size || n < 0) throw new IllegalArgumentException("!!!")
+    if (n > l.size || n < 0) throw new IllegalArgumentException(s"invalid choice: $n")
     else if (n == 0) Gen.const(Nil)
     else gen { (p, seed0) =>
       val buf = ArrayBuffer.empty[T]

--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -109,10 +109,11 @@ sealed abstract class Gen[+T] extends Serializable { self =>
    *  test property is side-effect free, eg it should not use external vars.
    *  This method is identical to [Gen.filter]. */
   def suchThat(f: T => Boolean): Gen[T] = new Gen[T] {
-    def doApply(p: P, seed: Seed) = {
-      val res = Gen.this.doApply(p, seed)
-      res.copy(s = { x:T => res.sieve(x) && f(x) })
-    }
+    def doApply(p: P, seed: Seed) =
+      p.useInitialSeed(seed) { (p0, s0) =>
+        val res = Gen.this.doApply(p0, s0)
+        res.copy(s = { x:T => res.sieve(x) && f(x) })
+      }
     override def sieveCopy(x: Any) =
       try Gen.this.sieveCopy(x) && f(x.asInstanceOf[T])
       catch { case _: java.lang.ClassCastException => false }
@@ -179,10 +180,11 @@ sealed abstract class Gen[+T] extends Serializable { self =>
 
   /** Put a label on the generator to make test reports clearer */
   def label(l: String): Gen[T] = new Gen[T] {
-    def doApply(p: P, seed: Seed) = {
-      val r = Gen.this.doApply(p, seed)
-      r.copy(l = r.labels + l)
-    }
+    def doApply(p: P, seed: Seed) =
+      p.useInitialSeed(seed) { (p0, s0) =>
+        val r = Gen.this.doApply(p0, s0)
+        r.copy(l = r.labels + l)
+      }
     override def sieveCopy(x: Any) = Gen.this.sieveCopy(x)
   }
 
@@ -254,7 +256,7 @@ object Gen extends GenArities{
 
   /** Generator factory method */
   private[scalacheck] def gen[T](f: (P, Seed) => R[T]): Gen[T] = new Gen[T] {
-    def doApply(p: P, seed: Seed) = f(p, seed)
+    def doApply(p: P, seed: Seed): R[T] = p.useInitialSeed(seed)(f)
   }
 
   //// Public interface ////
@@ -262,18 +264,49 @@ object Gen extends GenArities{
   /** Generator parameters, used by [[org.scalacheck.Gen.apply]] */
   sealed abstract class Parameters extends Serializable {
 
-    /** The size of the generated value. Generator implementations are allowed
-     *  to freely interpret (or ignore) this value. During test execution, the
-     *  value of this parameter is controlled by [[Test.Parameters.minSize]] and
-     *  [[Test.Parameters.maxSize]]. */
+    /**
+     * The size of the generated value. Generator implementations are
+     * allowed to freely interpret (or ignore) this value. During test
+     * execution, the value of this parameter is controlled by
+     * [[Test.Parameters.minSize]] and [[Test.Parameters.maxSize]].
+     */
     val size: Int
 
-    /** Create a copy of this [[Gen.Parameters]] instance with
-     *  [[Gen.Parameters.size]] set to the specified value. */
-    def withSize(size: Int): Parameters = cp(size = size)
+    /**
+     * Create a copy of this [[Gen.Parameters]] instance with
+     * [[Gen.Parameters.size]] set to the specified value.
+     */
+    def withSize(size: Int): Parameters =
+      cp(size = size)
+
+    /**
+     *
+     */
+    val initialSeed: Option[Seed]
+
+    def withInitialSeed(seed: Seed): Parameters =
+      cp(initialSeed = Some(seed))
+
+    def withInitialSeed(n: Long): Parameters =
+      cp(initialSeed = Some(Seed(n)))
+
+    def withNoInitialSeed: Parameters =
+      cp(initialSeed = None)
+
+    def useInitialSeed[A](seed: Seed)(f: (Parameters, Seed) => A): A =
+      initialSeed match {
+        case Some(s) => f(this.withNoInitialSeed, s)
+        case None => f(this, seed)
+      }
+
+    def startInitialSeed[A](f: (Parameters, Seed) => A): A =
+      initialSeed match {
+        case Some(s) => f(this.withNoInitialSeed, s)
+        case None => f(this, Seed.random())
+      }
 
     // private since we can't guarantee binary compatibility for this one
-    private case class cp(size: Int = size) extends Parameters
+    private case class cp(size: Int = size, initialSeed: Option[Seed] = None) extends Parameters
   }
 
   /** Provides methods for creating [[org.scalacheck.Gen.Parameters]] values */
@@ -281,6 +314,7 @@ object Gen extends GenArities{
     /** Default generator parameters instance. */
     val default: Parameters = new Parameters {
       val size: Int = 100
+      val initialSeed: Option[Seed] = None
     }
   }
 

--- a/src/main/scala/org/scalacheck/Prop.scala
+++ b/src/main/scala/org/scalacheck/Prop.scala
@@ -484,7 +484,7 @@ object Prop {
     pv: P => Prop,
     pp: A => Pretty
   ): Prop = Prop { prms =>
-    val gr = g.doApply(prms, Seed.random())
+    val gr = prms.startInitialSeed(g.doApply)
     gr.retrieve match {
       case None => undecided(prms)
       case Some(x) =>
@@ -507,7 +507,7 @@ object Prop {
     pv: P => Prop,
     pp1: T1 => Pretty
   ): Prop = Prop { prms =>
-    val gr = g1.doApply(prms, Seed.random())
+    val gr = prms.startInitialSeed(g1.doApply)
     gr.retrieve match {
       case None => undecided(prms)
       case Some(x) =>
@@ -705,7 +705,7 @@ object Prop {
   )(implicit pv: P => Prop, pp: T => Pretty
   ): Prop = Prop { prms =>
 
-    val gr = g.doApply(prms, Seed.random())
+    val gr = prms.startInitialSeed(g.doApply)
     val labels = gr.labels.mkString(",")
 
     def result(x: T) = {

--- a/src/main/scala/org/scalacheck/Properties.scala
+++ b/src/main/scala/org/scalacheck/Properties.scala
@@ -9,6 +9,8 @@
 
 package org.scalacheck
 
+import org.scalacheck.rng.Seed
+
 import language.reflectiveCalls
 
 import util.ConsoleReporter
@@ -99,4 +101,19 @@ class Properties(val name: String) {
   }
 
   lazy val property = new PropertySpecifier()
+
+  sealed class PropertyWithSeedSpecifier() {
+    def update(propName: String, optSeed: Option[String], p: => Prop) = {
+      val fullName = s"$name.$propName"
+      optSeed match {
+        case Some(encodedSeed) =>
+          val seed = Seed.fromBase64(encodedSeed)
+          props += ((fullName, Prop.delay(p).useSeed(fullName, seed)))
+        case None =>
+          props += ((fullName, Prop.delay(p).viewSeed(fullName)))
+      }
+    }
+  }
+
+  lazy val propertyWithSeed = new PropertyWithSeedSpecifier()
 }

--- a/src/main/scala/org/scalacheck/Test.scala
+++ b/src/main/scala/org/scalacheck/Test.scala
@@ -312,10 +312,9 @@ object Test {
     val iterations = math.ceil(minSuccessfulTests / (workers: Double))
     val sizeStep = (maxSize-minSize) / (iterations*workers)
     var stop = false
-    val genPrms = initialSeed match {
-      case None => Gen.Parameters.default
-      case Some(seed) => Gen.Parameters.default.withInitialSeed(seed)
-    }
+    //val seed = p.fixedSeed.getOrElse(rng.Seed.random)
+    //val genPrms = Gen.Parameters.default.withInitialSeed(seed)
+    val genPrms = Gen.Parameters.default
 
     def workerFun(workerIdx: Int): Result = {
       var n = 0  // passed tests

--- a/src/main/scala/org/scalacheck/rng/Seed.scala
+++ b/src/main/scala/org/scalacheck/rng/Seed.scala
@@ -11,6 +11,38 @@ sealed abstract class Seed extends Serializable {
   protected val c: Long
   protected val d: Long
 
+  /**
+   * Generate a Base-64 representation of this seed.
+   *
+   * Given a seed, this method will return a String with 44
+   * characters, according to the web-safe Base-64 specification
+   * (i.e. using minus (-) and underscore (_) in addition to
+   * alphanumeric characters).
+   *
+   * The 256-bit seed is serialized as a little-endian array of 64-bit
+   * Long values. Strings produced by this method are guaranteed to be
+   * parseable by the Seed.fromBase64 method.
+   */
+  def toBase64: String = {
+    def enc(x: Long): Char = Seed.Alphabet((x & 0x3f).toInt)
+    val chars = new Array[Char](44)
+    def encode(x: Long, shift: Int, i: Int, rest: List[Long]): String =
+      if (shift < 58) {
+        chars(i) = enc(x >>> shift)
+        encode(x, shift + 6, i + 1, rest)
+      } else rest match {
+        case Nil =>
+          chars(i) = enc(x >>> 60)
+          chars(i + 1) = '='
+          new String(chars)
+        case y :: ys =>
+          val sh = 64 - shift
+          chars(i) = enc((x >>> shift) | (y << sh))
+          encode(y, (6 - sh) % 6, i + 1, ys)
+      }
+    encode(a, 0, 0, b :: c :: d :: Nil)
+  }
+
   /** Generate the next seed in the RNG's sequence. */
   def next: Seed = {
     import java.lang.Long.rotateLeft
@@ -48,7 +80,9 @@ sealed abstract class Seed extends Serializable {
 
 object Seed {
 
-  private case class apply(a: Long, b: Long, c: Long, d: Long) extends Seed
+  private case class apply(a: Long, b: Long, c: Long, d: Long) extends Seed {
+    override def toString: String = "Seed(%016x, %016x, %016x, %016x)" format (a, b, c, d)
+  }
 
   /** Generate a deterministic seed. */
   def apply(s: Long): Seed = {
@@ -56,6 +90,72 @@ object Seed {
     var seed: Seed = Seed(0xf1ea5eed, s, s, s)
     while (i < 20) { seed = seed.next; i += 1 }
     seed
+  }
+
+  /**
+   * Generate a seed directly from four Long values.
+   *
+   * Warning: unlike Seed.apply(Long), this method just directly
+   * constructs a seed from the four Long values. Prefer using
+   * `Seed(Long)` if you aren't sure whether these will be good seed
+   * values.
+   */
+  def fromLongs(a: Long, b: Long, c: Long, d: Long): Seed =
+    apply(a, b, c, d)
+
+  /**
+   * Alphabet of characters used by the `toBase64` method.
+   *
+   * Since we're using the web-safe Base-64 specification, we are
+   * using minus (-) and underscore(_) in addition to the alphanumeric
+   * characters.
+   */
+  private[scalacheck] final val Alphabet: Array[Char] =
+    ((0 until 26).map(i => ('A' + i).toChar) ++
+      (0 until 26).map(i => ('a' + i).toChar) ++
+      (0 until 10).map(i => ('0' + i).toChar) ++
+      Vector('-', '_')).toArray
+
+  /**
+   * Parse a Base-64 encoded seed, returning a Seed value.
+   *
+   * This method requires the exact format produced by `toBase64`
+   * (i.e. a 44-character string using the web-safe Base-64
+   * alphabet). Other encodings must produce precisely the same
+   * outputs to be supported.
+   *
+   * This method will throw an IllegalArgumentException if parsing
+   * fails.
+   */
+  def fromBase64(s: String): Seed = {
+    def fail(s: String): Nothing = throw new IllegalArgumentException(s)
+    if (s.length != 44) fail(s"wrong Base64 length: $s")
+    if (s.charAt(43) != '=') fail(s"wrong Base64 format: $s")
+    if (s.charAt(42) == '=') fail(s"wrong Base64 format: $s")
+
+    def dec(c: Char): Long =
+      if ('A' <= c && c <= 'Z') (c - 'A').toLong
+      else if ('a' <= c && c <= 'z') ((c - 'a') + 26).toLong
+      else if ('0' <= c && c <= '9') ((c - '0') + 52).toLong
+      else if (c == '-') 62L
+      else if (c == '_') 63L
+      else fail(s"illegal Base64 character: $c")
+
+    val longs = new Array[Long](4)
+    def decode(x: Long, shift: Int, i: Int, j: Int): Seed =
+      if (i >= 43) {
+        Seed.fromLongs(longs(0), longs(1), longs(2), longs(3))
+      } else {
+        val b = dec(s.charAt(i))
+        if (shift < 58) {
+          decode(x | (b << shift), shift + 6, i + 1, j)
+        } else {
+          longs(j) = x | (b << shift)
+          val sh = 64 - shift
+          decode(b >>> sh, 6 - sh, i + 1, j + 1)
+        }
+      }
+    decode(0L, 0, 0, 0)
   }
 
   /** Generate a random seed. */

--- a/src/main/scala/org/scalacheck/rng/Seed.scala
+++ b/src/main/scala/org/scalacheck/rng/Seed.scala
@@ -65,6 +65,20 @@ sealed abstract class Seed extends Serializable {
   }
 
   /**
+   * This is a quick way of deterministically sliding this RNG to a
+   * different part of the PRNG sequence.
+   *
+   * We use this as an easy way to "split" the RNG off into a new part
+   * of the sequence. We want to do this in situations where we've
+   * already called .next several times, and we want to avoid
+   * repeating those numbers while preserving determinism.
+   */
+  def slide: Seed = {
+    val (n, s) = long
+    s.reseed(n)
+  }
+
+  /**
    * Generates a Long value.
    *
    * The values will be uniformly distributed. */

--- a/src/test/scala/org/scalacheck/PropSpecification.scala
+++ b/src/test/scala/org/scalacheck/PropSpecification.scala
@@ -198,4 +198,14 @@ object PropSpecification extends Properties("Prop") {
       val set = (1 to 20).map(_ => p(params).success).toSet
       Prop(set == Set(x)).label(s"$set == Set($x)")
     }
+
+  property("prop.useSeed is deterministic (pt. 2)") =
+    forAll { (g1: Gen[Int], g2: Gen[Int], g3: Gen[Int], n: Long) =>
+      val params = Gen.Parameters.default
+      val p0 = Prop.forAll(g1, g2, g3) { (x, y, z) => x == y && y == z }
+      val p = p0.useSeed("some name", rng.Seed(n))
+      val x = p(params).success
+      val set = (1 to 20).map(_ => p(params).success).toSet
+      Prop(set == Set(x)).label(s"$set == Set($x)")
+    }
 }

--- a/src/test/scala/org/scalacheck/PropSpecification.scala
+++ b/src/test/scala/org/scalacheck/PropSpecification.scala
@@ -182,10 +182,20 @@ object PropSpecification extends Properties("Prop") {
 
   property("lzy") = { lzy(???); proved }
 
-  property("Gen.Parameters.withInitialSeed") = forAll { (p: Prop) =>
-    val params = Gen.Parameters.default.withInitialSeed(999L)
-    val x = p(params).success
-    val set = (1 to 20).map(_ => p(params).success).toSet
-    Prop(set == Set(x)).label(s"$set == Set($x)")
-  }
+  property("Gen.Parameters.withInitialSeed is deterministic") =
+    forAll { (p: Prop) =>
+      val params = Gen.Parameters.default.withInitialSeed(999L)
+      val x = p(params).success
+      val set = (1 to 20).map(_ => p(params).success).toSet
+      Prop(set == Set(x)).label(s"$set == Set($x)")
+    }
+
+  property("prop.useSeed is deterministic") =
+    forAll { (p0: Prop, n: Long) =>
+      val params = Gen.Parameters.default
+      val p = p0.useSeed("some name", rng.Seed(n))
+      val x = p(params).success
+      val set = (1 to 20).map(_ => p(params).success).toSet
+      Prop(set == Set(x)).label(s"$set == Set($x)")
+    }
 }

--- a/src/test/scala/org/scalacheck/PropSpecification.scala
+++ b/src/test/scala/org/scalacheck/PropSpecification.scala
@@ -181,4 +181,11 @@ object PropSpecification extends Properties("Prop") {
   property("delay") = { delay(???); proved }
 
   property("lzy") = { lzy(???); proved }
+
+  property("Gen.Parameters.withInitialSeed") = forAll { (p: Prop) =>
+    val params = Gen.Parameters.default.withInitialSeed(999L)
+    val x = p(params).success
+    val set = (1 to 20).map(_ => p(params).success).toSet
+    Prop(set == Set(x)).label(s"$set == Set($x)")
+  }
 }


### PR DESCRIPTION
This commit adds an `initialSeed` parameter to the Parameter types
that Test and Gen use to control test execution. When set to `None`,
things behave as they usually do, but when set to `Some(seed)`, that
seed will be used to start the execution.

This makes it easier to configure repeatable tests. In the future, you
could imagine ScalaCheck emitting which seed it started with during a
failing test, and providing an interface for re-running the failing
test with the same seed.

Also included are some tests to ensure generators are deterministic.
We can add more of these for different types of generators in the future
as needed.

Review by @rickynils and @sirthias.
