### PR TITLE
String generators added.

### DIFF
--- a/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
@@ -200,6 +200,26 @@ object GenSpecification extends Properties("Gen") {
     s.forall(_.isLetterOrDigit)
   }
 
+  property("numStr") = forAll(numStr) { s =>
+    s.length >= 0 && s.forall(_.isDigit)
+  }
+
+  property("alphaUpperStr") = forAll(alphaUpperStr) { s =>
+    s.length >= 0 && s.forall(_.isUpper)
+  }
+
+  property("alphaLowerStr") = forAll(alphaLowerStr) { s =>
+    s.length >= 0 && s.forall(_.isLower)
+  }
+
+  property("alphaStr") = forAll(alphaStr) { s =>
+    s.length >= 0 && s.forall(_.isLetter)
+  }
+
+  property("alphaNumStr") = forAll(alphaNumStr) { s =>
+    s.length >= 0 && s.forall(_.isLetterOrDigit)
+  }
+
   // BigDecimal generation is tricky; just ensure that the generator gives
   // its constructor valid values.
   property("BigDecimal") = forAll { _: BigDecimal => true }

--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -649,27 +649,27 @@ object Gen extends GenArities{
   def identifier: Gen[String] = (for {
     c <- alphaLowerChar
     cs <- listOf(alphaNumChar)
-  } yield (c::cs).mkString).suchThat(_.forall(_.isLetterOrDigit))
+  } yield (c::cs).mkString)
 
   /** Generates a string of digits */
   def numStr: Gen[String] =
-    listOf(numChar).map(_.mkString).suchThat(_.forall(_.isDigit))
+    listOf(numChar).map(_.mkString)
 
   /** Generates a string of upper-case alpha characters */
   def alphaUpperStr: Gen[String] =
-    listOf(alphaUpperChar).map(_.mkString).suchThat(_.forall(_.isUpper))
+    listOf(alphaUpperChar).map(_.mkString)
 
   /** Generates a string of lower-case alpha characters */
   def alphaLowerStr: Gen[String] =
-      listOf(alphaLowerChar).map(_.mkString).suchThat(_.forall(_.isLower))
+      listOf(alphaLowerChar).map(_.mkString)
 
   /** Generates a string of alpha characters */
   def alphaStr: Gen[String] =
-    listOf(alphaChar).map(_.mkString).suchThat(_.forall(_.isLetter))
+    listOf(alphaChar).map(_.mkString)
 
   /** Generates a string of alphanumerical characters */
   def alphaNumStr: Gen[String] =
-    listOf(alphaNumChar).map(_.mkString).suchThat(_.forall(_.isLetterOrDigit))
+    listOf(alphaNumChar).map(_.mkString)
 
 
   //// Number Generators ////

--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -649,15 +649,27 @@ object Gen extends GenArities{
   def identifier: Gen[String] = (for {
     c <- alphaLowerChar
     cs <- listOf(alphaNumChar)
-  } yield (c::cs).mkString).suchThat(_.forall(c => c.isLetter || c.isDigit))
+  } yield (c::cs).mkString).suchThat(_.forall(_.isLetterOrDigit))
+
+  /** Generates a string of digits */
+  def numStr: Gen[String] =
+    listOf(numChar).map(_.mkString).suchThat(_.forall(_.isDigit))
+
+  /** Generates a string of upper-case alpha characters */
+  def alphaUpperStr: Gen[String] =
+    listOf(alphaUpperChar).map(_.mkString).suchThat(_.forall(_.isUpper))
+
+  /** Generates a string of lower-case alpha characters */
+  def alphaLowerStr: Gen[String] =
+      listOf(alphaLowerChar).map(_.mkString).suchThat(_.forall(_.isLower))
 
   /** Generates a string of alpha characters */
   def alphaStr: Gen[String] =
     listOf(alphaChar).map(_.mkString).suchThat(_.forall(_.isLetter))
 
-  /** Generates a string of digits */
-  def numStr: Gen[String] =
-    listOf(numChar).map(_.mkString).suchThat(_.forall(_.isDigit))
+  /** Generates a string of alphanumerical characters */
+  def alphaNumStr: Gen[String] =
+    listOf(alphaNumChar).map(_.mkString).suchThat(_.forall(_.isLetterOrDigit))
 
 
   //// Number Generators ////


### PR DESCRIPTION
* Added the string generators `alphaUpperStr`, `alphaLowerStr` and `alphaNumStr`.
* Changed the order of string generators to match that of the character generators.
* Added tests for `numStr`, `alphaUpperStr`, `alphaLowerStr`, `alphaStr` and `alphaNumStr`.
* Changed `_.forall(c => c.isLetter || c.isDigit)` to `_.forall(_.isLetterOrDigit)` in the definition of `identifier`.