### PR TITLE
Allow type classes to be serializable

### DIFF
--- a/jvm/src/test/scala/org/scalacheck/SerializabilitySpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/SerializabilitySpecification.scala
@@ -1,0 +1,97 @@
+package org.scalacheck
+
+import java.io.{ ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream }
+
+import Prop.proved
+
+import util.SerializableCanBuildFroms._
+
+object SerializabilitySpecification extends Properties("Serializability") {
+
+  // adapted from https://github.com/milessabin/shapeless/blob/6b870335c219d59079b46eddff15028332c0c294/core/jvm/src/test/scala/shapeless/serialization.scala#L42-L62
+  private def serializable[M](m: M): Boolean = {
+    val baos = new ByteArrayOutputStream
+    val oos = new ObjectOutputStream(baos)
+    var ois: ObjectInputStream = null
+    try {
+      oos.writeObject(m)
+      oos.close()
+      val bais = new ByteArrayInputStream(baos.toByteArray)
+      ois = new ObjectInputStream(bais)
+      val m2 = ois.readObject() // just ensure we can read it back
+      ois.close()
+      true
+    } catch {
+      case thr: Throwable =>
+        thr.printStackTrace
+        false
+    } finally {
+      oos.close()
+      if (ois != null) ois.close()
+    }
+  }
+
+  def serializableArbitrary[T: Arbitrary](name: String) =
+    property(s"Arbitrary[$name] serializability") = {
+      val arb = implicitly[Arbitrary[T]]
+      assert(serializable(arb))
+
+      // forcing the calculation of a value, to trigger the initialization of any lazily initialized field
+      arb.arbitrary.sample
+      assert(serializable(arb))
+
+      proved
+    }
+
+  def serializableGen[T](name: String, gen: Gen[T]) =
+    property(s"Gen[$name] serializability") = {
+      assert(serializable(gen))
+
+      // forcing the calculation of a value, to trigger the initialization of any lazily initialized field
+      gen.sample
+      assert(serializable(gen))
+
+      proved
+    }
+
+  def serializableCogen[T: Cogen](name: String) =
+    property(s"Cogen[$name] serializability") = {
+      val gen = Cogen[T]
+      assert(serializable(gen))
+
+      proved
+    }
+
+  def serializableShrink[T: Shrink](name: String) =
+    property(s"Shrink[$name] serializability") = {
+      val shrink = implicitly[Shrink[T]]
+      assert(serializable(shrink))
+
+      proved
+    }
+
+  serializableArbitrary[String]("String")
+  serializableArbitrary[Int]("Int")
+  serializableArbitrary[Double]("Double")
+  serializableArbitrary[Boolean]("Boolean")
+
+  serializableGen("identifier", Gen.identifier)
+  serializableGen("oneOf", Gen.oneOf(true, false))
+  serializableGen("choose", Gen.choose(1, 10))
+
+  serializableCogen[String]("String")
+  serializableCogen[Int]("Int")
+  serializableCogen[Double]("Double")
+  serializableCogen[Boolean]("Boolean")
+
+  serializableShrink[String]("String")
+  serializableShrink[Int]("Int")
+  serializableShrink[Double]("Double")
+  serializableShrink[Boolean]("Boolean")
+
+  property("Seed serializability") = {
+    assert(serializable(rng.Seed(1L)))
+    proved
+  }
+
+}

--- a/src/main/scala/org/scalacheck/Arbitrary.scala
+++ b/src/main/scala/org/scalacheck/Arbitrary.scala
@@ -14,9 +14,10 @@ import concurrent.Future
 import scala.util.{Failure, Success, Try}
 
 import util.{FreqMap, Buildable}
+import util.SerializableCanBuildFroms._
 
 
-sealed abstract class Arbitrary[T] {
+sealed abstract class Arbitrary[T] extends Serializable {
   val arbitrary: Gen[T]
 }
 
@@ -122,9 +123,9 @@ private[scalacheck] sealed trait ArbitraryLowPriority {
       (0xFFFF, 0xFFFF)
     )
 
-    Gen.frequency(validRangesInclusive.map {
+    Gen.frequency((validRangesInclusive.map {
       case (first, last) => (last + 1 - first, Gen.choose[Char](first, last))
-    }: _*)
+    }: List[(Int, Gen[Char])]): _*)
   }
 
   /** Arbitrary instance of Byte */

--- a/src/main/scala/org/scalacheck/Cogen.scala
+++ b/src/main/scala/org/scalacheck/Cogen.scala
@@ -18,7 +18,7 @@ import scala.util.{ Try, Success, Failure }
 import Arbitrary.arbitrary
 import rng.Seed
 
-sealed trait Cogen[-T] {
+sealed trait Cogen[-T] extends Serializable {
 
   def perturb(seed: Seed, t: T): Seed
 

--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -14,12 +14,13 @@ import language.implicitConversions
 
 import rng.Seed
 import util.Buildable
+import util.SerializableCanBuildFroms._
 
 import scala.annotation.tailrec
 import scala.collection.immutable.TreeMap
 import scala.collection.mutable.ArrayBuffer
 
-sealed abstract class Gen[+T] {
+sealed abstract class Gen[+T] extends Serializable {
 
   //// Private interface ////
 
@@ -230,7 +231,7 @@ object Gen extends GenArities{
   //// Public interface ////
 
   /** Generator parameters, used by [[org.scalacheck.Gen.apply]] */
-  sealed abstract class Parameters {
+  sealed abstract class Parameters extends Serializable {
 
     /** The size of the generated value. Generator implementations are allowed
      *  to freely interpret (or ignore) this value. During test execution, the
@@ -255,7 +256,7 @@ object Gen extends GenArities{
   }
 
   /** A wrapper type for range types */
-  trait Choose[T] {
+  trait Choose[T] extends Serializable {
     /** Creates a generator that returns a value in the given inclusive range */
     def choose(min: T, max: T): Gen[T]
   }

--- a/src/main/scala/org/scalacheck/Prop.scala
+++ b/src/main/scala/org/scalacheck/Prop.scala
@@ -24,7 +24,7 @@ sealed class PropFromFun(f: Gen.Parameters => Prop.Result) extends Prop {
 
 @Platform.JSExportDescendentClasses
 @Platform.JSExportDescendentObjects
-sealed abstract class Prop {
+sealed abstract class Prop extends Serializable {
 
   import Prop.{Result, Proof, True, False, Exception, Undecided,
     provedToTrue, secure, mergeRes}

--- a/src/main/scala/org/scalacheck/Shrink.scala
+++ b/src/main/scala/org/scalacheck/Shrink.scala
@@ -12,9 +12,10 @@ package org.scalacheck
 import language.higherKinds
 
 import util.Buildable
+import util.SerializableCanBuildFroms._
 import scala.collection.{ JavaConversions => jcl }
 
-sealed abstract class Shrink[T] {
+sealed abstract class Shrink[T] extends Serializable {
   def shrink(x: T): Stream[T]
 }
 

--- a/src/main/scala/org/scalacheck/rng/Seed.scala
+++ b/src/main/scala/org/scalacheck/rng/Seed.scala
@@ -5,7 +5,7 @@ package org.scalacheck.rng
  *
  * http://burtleburtle.net/bob/rand/smallprng.html
  */
-sealed abstract class Seed {
+sealed abstract class Seed extends Serializable {
   protected val a: Long
   protected val b: Long
   protected val c: Long

--- a/src/main/scala/org/scalacheck/util/Buildable.scala
+++ b/src/main/scala/org/scalacheck/util/Buildable.scala
@@ -11,16 +11,42 @@ package org.scalacheck.util
 
 import language.higherKinds
 
-import collection._
+import collection.{ Map => _, _ }
 import generic.CanBuildFrom
 
-trait Buildable[T,C] {
+trait Buildable[T,C] extends Serializable {
   def builder: mutable.Builder[T,C]
   def fromIterable(it: Traversable[T]): C = {
     val b = builder
     b ++= it
     b.result()
   }
+}
+
+/**
+  * CanBuildFrom instances implementing Serializable, so that the objects capturing those can be
+  * serializable too.
+  */
+object SerializableCanBuildFroms {
+
+  implicit def listCanBuildFrom[T]: CanBuildFrom[List[T], T, List[T]] =
+    new CanBuildFrom[List[T], T, List[T]] with Serializable {
+      def apply(from: List[T]) = List.newBuilder[T]
+      def apply() = List.newBuilder[T]
+    }
+
+  implicit def bitsetCanBuildFrom[T]: CanBuildFrom[BitSet, Int, BitSet] =
+    new CanBuildFrom[BitSet, Int, BitSet] with Serializable {
+      def apply(from: BitSet) = BitSet.newBuilder
+      def apply() = BitSet.newBuilder
+    }
+
+  implicit def mapCanBuildFrom[T, U]: CanBuildFrom[Map[T, U], (T, U), Map[T, U]] =
+    new CanBuildFrom[Map[T, U], (T, U), Map[T, U]] with Serializable {
+      def apply(from: Map[T, U]) = Map.newBuilder[T, U]
+      def apply() = Map.newBuilder[T, U]
+    }
+
 }
 
 object Buildable {


### PR DESCRIPTION
This PR allows `Arbitrary`, `Gen`, `Cogen`, `Shrink` instances, to be `Serializable`, so that these can be used in contexts relying on Java serialization (from closures with Spark in particular).

The unit tests in this PR are far from exhaustive, but illustrate that simple type class instances are indeed serializable.

Note that scalacheck relying on `CanBuildFrom` at some places tends to break serializability by default, as default `CanBuildFrom` instances from the standard library are usually not serializable. To circumvent that, this PR adds a few serializable `CanBuildFrom` instances (in `SerializableCanBuildFroms`) that get implicitly found if `SerializableCanBuildFroms._` is imported.