### PR TITLE
0xFFFF Is also not unicode.

### DIFF
--- a/src/main/scala/org/scalacheck/Arbitrary.scala
+++ b/src/main/scala/org/scalacheck/Arbitrary.scala
@@ -120,7 +120,7 @@ private[scalacheck] sealed trait ArbitraryLowPriority {
     // also exclude 0xFFFF as it is not unicode: http://bit.ly/2cVBrzK
     val validRangesInclusive = List[(Char, Char)](
       (0x0000, 0xD7FF),
-      (0xE000, 0xFFFD),
+      (0xE000, 0xFFFD)
     )
 
     Gen.frequency((validRangesInclusive.map {

--- a/src/main/scala/org/scalacheck/Arbitrary.scala
+++ b/src/main/scala/org/scalacheck/Arbitrary.scala
@@ -117,10 +117,10 @@ private[scalacheck] sealed trait ArbitraryLowPriority {
   /** Arbitrary instance of Char */
   implicit lazy val arbChar: Arbitrary[Char] = Arbitrary {
     // exclude 0xFFFE due to this bug: http://bit.ly/1QryQZy
+    // also exclude 0xFFFF as it is not unicode: http://bit.ly/2cVBrzK
     val validRangesInclusive = List[(Char, Char)](
       (0x0000, 0xD7FF),
       (0xE000, 0xFFFD),
-      (0xFFFF, 0xFFFF)
     )
 
     Gen.frequency((validRangesInclusive.map {


### PR DESCRIPTION
This issue came up generating strings for use in Xml; code-point 0xFFFF is for internal use only see http://bit.ly/2cVBrzK. Since the code already excludes the other internal character 0xFFFE it seems to make sense to include this one too.