### PR TITLE
CogenSpecification

### DIFF
--- a/jvm/src/test/scala/org/scalacheck/CogenSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/CogenSpecification.scala
@@ -1,0 +1,150 @@
+package org.scalacheck
+
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen.listOfN
+import org.scalacheck.GenSpecification.arbSeed
+import org.scalacheck.Prop.forAll
+import org.scalacheck.rng.Seed
+
+import scala.util.Try
+
+object CogenSpecification extends Properties("Cogen") {
+
+  // We need a customized definition of equality for some of our tests.
+  trait Equal[A] {
+    def equal(a1: A, a2: A): Boolean
+  }
+
+  object Equal extends EqualLowPriority {
+
+    def apply[A: Equal]: Equal[A] = implicitly
+
+    // Value equality for arrays as opposed to reference equality, consistent with other sequences.
+    implicit def arrayEqual[A: Equal]: Equal[Array[A]] = new Equal[Array[A]] {
+      override def equal(a1: Array[A], a2: Array[A]) =
+        a1.corresponds(a2)(Equal[A].equal)
+    }
+
+    // Two thunks are equal if evaluating them results in the same value.
+    implicit def function0Equal[A: Equal]: Equal[() => A] = new Equal[() => A] {
+      override def equal(a1: () => A, a2: () => A) =
+        Equal[A].equal(a1(), a2())
+    }
+
+    // Two exceptions are equal if they have the same string representation.
+    implicit val exceptionEqual = new Equal[Exception] {
+      override def equal(a1: Exception, a2: Exception): Boolean =
+        a1.toString == a2.toString
+    }
+
+    // Two throwables are equal if they have the same string representation.
+    implicit val throwableEqual = new Equal[Throwable] {
+      override def equal(a1: Throwable, a2: Throwable): Boolean =
+        a1.toString == a2.toString
+    }
+
+    // Two cogens are equal if for all combinations of seeds and values they product the same result.
+    implicit def cogenEqual[A: Arbitrary]: Equal[Cogen[A]] = new Equal[Cogen[A]] {
+      def equal(a1: Cogen[A], a2: Cogen[A]): Boolean =
+        listOfN(100, arbitrary[(Seed, A)]).sample.get.forall {
+          case (x, y) => a1.perturb(x, y) == a2.perturb(x, y)
+        }
+    }
+  }
+
+  // Avoid reimplementing equality for other standard classes.
+  trait EqualLowPriority {
+    implicit def universal[A] = new Equal[A] {
+      override def equal(a1: A, a2: A): Boolean = a1 == a2
+    }
+  }
+
+  // A version of distinct that accepts a custom notion of equality.
+  def distinct[A: Equal](as: List[A]): List[A] =
+    as.foldLeft(List.empty[A])((b, a) => if (b.exists(Equal[A].equal(a, _))) b else a :: b)
+
+  implicit def arbFunction0[A: Arbitrary]: Arbitrary[() => A] =
+    Arbitrary(arbitrary[A].map(() => _))
+
+  implicit def arbCogen[A: Arbitrary : Cogen]: Arbitrary[Cogen[A]] =
+    Arbitrary(arbitrary[A => A].map(Cogen[A].contramap(_)))
+
+  // Cogens should follow these laws.
+  object CogenLaws {
+
+    /*
+    A cogen should always generate different outputs for inputs that are not equal.
+    Note that since we are using pseudorandom number generation this is only required approximately.
+    In particular, if the space of the input is larger than the space of the seed (2^256) there is a
+    possibility of legitimate collisions, but this is vanishingly small for the sample sizes we are using.
+     */
+    def uniqueness[A: Equal : Arbitrary : Cogen]: Prop =
+      forAll { (seed: Seed, as: List[A]) =>
+        as.map(Cogen[A].perturb(seed, _)).toSet.size == distinct(as).size
+      }
+
+    // A Cogen should always generate the same output for a given seed and input.
+    def consistency[A: Arbitrary : Cogen]: Prop =
+      forAll { (seed: Seed, a: A) =>
+        Cogen[A].perturb(seed, a) == Cogen[A].perturb(seed, a)
+      }
+  }
+
+  def cogenLaws[A: Equal : Arbitrary : Cogen]: Properties =
+    new Properties("cogenLaws") {
+      property("uniqueness") = CogenLaws.uniqueness[A]
+      property("consistency") = CogenLaws.consistency[A]
+    }
+
+  // A Cogen is a contravariant functor and should follow the laws for contravariant functors.
+  object ContravariantLaws {
+
+    // Contramapping over a Cogen with the identity function should return the Cogen unchanged.
+    def identity[A: Equal : Arbitrary : Cogen]: Prop =
+      forAll { (fa: Cogen[A]) =>
+        Equal[Cogen[A]].equal(fa.contramap(a => a), fa)
+      }
+
+    // Contramapping with f and g is the same as contramapping with the composition of f and g.
+    def composition[A, B, C](implicit eq: Equal[Cogen[C]],
+                             arb1: Arbitrary[Cogen[A]],
+                             arb2: Arbitrary[B => A],
+                             arb3: Arbitrary[C => B]): Prop =
+      forAll { (fa: Cogen[A], f: B => A, g: C => B) =>
+        Equal[Cogen[C]].equal(fa.contramap(f).contramap(g), fa.contramap(f compose g))
+      }
+  }
+
+  def contravariantLaws: Properties =
+    new Properties("contravariantLaws") {
+      property("identity") = ContravariantLaws.identity[Int]
+      property("composition") = ContravariantLaws.composition[Int, Int, Int]
+    }
+
+  include(contravariantLaws)
+
+  include(cogenLaws[Unit], "cogenUnit.")
+  include(cogenLaws[Boolean], "cogenBoolean.")
+  include(cogenLaws[Byte], "cogenByte.")
+  include(cogenLaws[Short], "cogenShort.")
+  include(cogenLaws[Char], "cogenChar.")
+  include(cogenLaws[Int], "cogenInt.")
+  include(cogenLaws[Long], "cogenLong.")
+  include(cogenLaws[Float], "cogenFloat.")
+  include(cogenLaws[BigInt], "cogenBigInt.")
+  include(cogenLaws[BigDecimal], "cogenBigDecimal.")
+  include(cogenLaws[Option[Int]], "cogenOption.")
+  include(cogenLaws[Either[Int, Int]], "cogenEither.")
+  include(cogenLaws[Array[Int]], "cogenArray.")
+  include(cogenLaws[String], "cogenString.")
+  include(cogenLaws[List[Int]], "cogenList.")
+  include(cogenLaws[Vector[Int]], "cogenVector.")
+  include(cogenLaws[Stream[Int]], "cogenStream.")
+  include(cogenLaws[Set[Int]], "cogenSet.")
+  include(cogenLaws[Map[Int, Int]], "cogenMap.")
+  include(cogenLaws[() => Int], "cogenFunction0.")
+  include(cogenLaws[Exception], "cogenException.")
+  include(cogenLaws[Throwable], "cogenThrowable.")
+  include(cogenLaws[Try[Int]], "cogenTry.")
+  include(cogenLaws[Seq[Int]], "cogenSeq.")
+}

--- a/src/main/scala/org/scalacheck/Cogen.scala
+++ b/src/main/scala/org/scalacheck/Cogen.scala
@@ -11,14 +11,14 @@ package org.scalacheck
 
 import language.higherKinds
 import language.implicitConversions
-
+import scala.annotation.tailrec
 import scala.collection.immutable.BitSet
-import scala.util.{ Try, Success, Failure }
-
+import scala.util.{Failure, Success, Try}
 import Arbitrary.arbitrary
+import java.math.BigInteger
 import rng.Seed
 
-sealed trait Cogen[-T] extends Serializable {
+sealed trait Cogen[T] extends Serializable {
 
   def perturb(seed: Seed, t: T): Seed
 
@@ -43,7 +43,7 @@ object Cogen extends CogenArities with CogenLowPriority {
 
   def apply[T](f: (Seed, T) => Seed): Cogen[T] =
     new Cogen[T] {
-      def perturb(seed: Seed, t: T): Seed = f(seed, t).next
+      def perturb(seed: Seed, t: T): Seed = f(seed, t)
     }
 
   def it[T, U](f: T => Iterator[U])(implicit U: Cogen[U]): Cogen[T] =
@@ -75,8 +75,30 @@ object Cogen extends CogenArities with CogenLowPriority {
   implicit lazy val bigInt: Cogen[BigInt] =
     Cogen[Array[Byte]].contramap(_.toByteArray)
 
-  implicit lazy val bigDecimal: Cogen[BigDecimal] =
-    Cogen[(Int, Array[Byte])].contramap(x => (x.scale, x.bigDecimal.unscaledValue.toByteArray))
+  implicit lazy val bigDecimal: Cogen[BigDecimal] = {
+
+    // Normalize unscaled values and scaling factors by moving powers of ten from value to scaling factor.
+    @tailrec
+    def normalize(unscaled: BigInteger, scale: Int): (BigInteger, Int) = {
+      val divideAndRemainder = unscaled.divideAndRemainder(BigInteger.TEN)
+      val quotient = divideAndRemainder(0)
+      val remainder = divideAndRemainder(1)
+      val canNormalize = (unscaled.abs.compareTo(BigInteger.TEN) >= 0) &&
+        (remainder == BigInteger.ZERO) &&
+        (scale != Int.MaxValue) &&
+        (scale != Int.MinValue)
+      if (canNormalize) normalize(quotient, scale - 1) else (unscaled, scale)
+    }
+
+    // If the unscaled value is zero then the scaling factor doesn't matter. Otherwise perturb based on both.
+    Cogen((seed: Seed, n: BigDecimal) =>
+      if (n.bigDecimal.unscaledValue == BigInteger.ZERO)
+        Cogen[Int].perturb(seed, 0)
+      else {
+        val (unscaled, scale) = normalize(n.bigDecimal.unscaledValue, n.scale)
+        Cogen[(Int, Array[Byte])].perturb(seed, (scale, unscaled.toByteArray))
+    })
+  }
 
   implicit lazy val bitSet: Cogen[BitSet] =
     Cogen.it(_.iterator)


### PR DESCRIPTION
This proposal creates a new test suite for Cogen. The tests are based on the concept that Cogen instances should satisfy two properties:

**1. Consistency** - A given Cogen should always return the same output for the same seed and input. In other words, Cogen is referentially transparent.
**2. Uniqueness** - Given a seed, a Cogen should always return different outputs for inputs that are not equal. One can imagine a Cogen that does not do this (e.g. one that is only based on the length of a string to a model a function that only uses that information), but especially for Cogen instances that will generally be available implicitly this seems like a highly desirable property.

With a few minor provisions, all of the existing Cogen instances satisfy these laws. In the case of Function0, Array, Throwable, and Exception we need to use a different definition of equality than the standard `==` but these are fine. For BigDecimal there is a corner case where `BigDecimal(0, Int.MaxValue) == BigDecimal(0, Int.MinValue)` evaluates to true but the Cogen instances returns different values. Not quite sure how to handle that.

I also made a couple of minor changes to the code for Cogen itself. First, I removed the call to `.next` on constructing a new Cogen. I don't think this is necessary and by removing it we can establish several other nice laws for Cogen. Specifically, `contramap(a => a)` is now an identity function consistent with the laws for contravariant functors. Also, we can show that Cogen forms a Monoid and a Divisible (the contravariant equivalent of an Applicative). Hopefully this is not too much category theory but this does provide some additional ways to compose Cogen if someone wants to go down the road of creating more sophisticated arbitrary functions and provides some laws to reason about them.

This is my first pull request so open to any and all feedback. Hopefully this is helpful.