### PR TITLE
Make Cogen Invariant

### DIFF
--- a/src/main/scala/org/scalacheck/Cogen.scala
+++ b/src/main/scala/org/scalacheck/Cogen.scala
@@ -18,7 +18,7 @@ import scala.util.{ Try, Success, Failure }
 import Arbitrary.arbitrary
 import rng.Seed
 
-sealed trait Cogen[-T] extends Serializable {
+sealed trait Cogen[T] extends Serializable {
 
   def perturb(seed: Seed, t: T): Seed
 


### PR DESCRIPTION
It looks like there are issues with implicit resolution for Cogen. See example below. I believe this is related to the contravariance annotation for Cogen and its interaction with limitations in Scala's implicit search (Cogen[Any] is treated as a subtype of Cogen[A] for all A so in searching for the most specific implicit value the compiler infers a type to Any and then has divergence resolving subsequent search for implicit values). I believe this is the reason Ordering is not declared contravariant in the standard library. When I remove the contravariance annotation on Cogen the issue is resolved. All other tests still work with this change.

```
Welcome to Scala 2.12.0-RC1 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_91).
Type in expressions for evaluation. Or try :help.

scala> import org.scalacheck._
import org.scalacheck._

scala> Cogen[Int => Int]
<console>:15: error: diverging implicit expansion for type org.scalacheck.Cogen[Int => Int]
starting with method arbTuple22 in trait ArbitraryArities
       Cogen[Int => Int]
```
