### PR TITLE
Fix issue where return code could be seen as 0.

### DIFF
--- a/src/main/scala/org/scalacheck/Properties.scala
+++ b/src/main/scala/org/scalacheck/Properties.scala
@@ -60,20 +60,23 @@ class Properties(val name: String) {
   /** Convenience method that makes it possible to use this property collection
    *  as an application that checks itself on execution. Calls `System.exit`
    *  with the exit code set to the number of failed properties. */
-  def main(args: Array[String]): Unit = {
-    val ret = Test.cmdLineParser.parseParams(args) match {
+  def main(args: Array[String]): Unit =
+    Test.cmdLineParser.parseParams(args) match {
       case (applyCmdParams, Nil) =>
         val params = applyCmdParams(overrideParameters(Test.Parameters.default))
         val res = Test.checkProperties(params, this)
-        val failed = res.filter(!_._2.passed).size
-        failed
+        val numFailed = res.count(!_._2.passed)
+        if (numFailed > 0) {
+          println(s"Found $numFailed failing properties.")
+          System.exit(1)
+        } else {
+          System.exit(0)
+        }
       case (_, os) =>
         println(s"Incorrect options: $os")
         Test.cmdLineParser.printHelp
-        -1
+        System.exit(-1)
     }
-    if (ret != 0) System.exit(ret)
-  }
 
   /** Adds all properties from another property collection to this one */
   def include(ps: Properties): Unit =


### PR DESCRIPTION
Previously ScalaCheck tried to encode (and return) the number of
failing properties in the exit code. Unfortunately this meant that
multiples of 256 would be seen as having 0 failures.

The new code uses -1 for invalid arguments, 0 for success, and 1 for
one or more failures. The number of failing properties is also printed
explicitly, so that the user can still see this information.

Fixes #240.