### PR TITLE
Gen.infiniteStream

### DIFF
--- a/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
@@ -161,6 +161,10 @@ object GenSpecification extends Properties("Gen") {
     l.length == 0
   }
 
+  property("infiniteStream") = forAll(infiniteStream(arbitrary[Int]), arbitrary[Short]) { (s, n) =>
+    s.drop(n & 0xffff).nonEmpty
+  }
+
   property("someOf") = forAll { l: List[Int] =>
     forAll(someOf(l))(_.toList.forall(l.contains))
   }


### PR DESCRIPTION
Adds a Gen instance for generating an infinite stream of values given a generator for the type of the underlying values. This is useful for testing that functions designed to be able to handle infinite data structures (e.g. through lazy evaluation) are working correctly. Also includes a new test for this instance. See #280.