### PR TITLE
Improve retryUntil's behavior during failure.

### DIFF
--- a/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
@@ -52,6 +52,12 @@ object GenSpecification extends Properties("Gen") {
 
   property("retryUntil") = forAll((g: Gen[Int]) => g.retryUntil(_ => true) == g)
 
+  property("retryUntil doesn't run forever") =
+    forAll((g: Gen[Int]) => Try(g.retryUntil(_ => false).sample).isFailure)
+
+  property("retryUntil requires valid parameters") =
+    forAll((g: Gen[Int]) => Try(g.retryUntil(_ => false, 0)).isFailure)
+
   property("const") = forAll { (x:Int, prms:Parameters, seed: Seed) =>
     const(x)(prms, seed) == Some(x)
   }


### PR DESCRIPTION
Previously retryUntil would throw a StackOverflowException if the
generator failed too many times. It's not obvious to users that the
problem is their generator and/or predicate.

This commit replaces this implicit depth limit with an explicit cutoff
after 10000 tries (along with a custom Exception). It also provides a
two-argument variant of retryUntil that allows the user to specify how
many tries are allowed.

This change should improve the situation in #232.