### PR TITLE
Add support for Duration and FiniteDuration

### DIFF
--- a/jvm/src/test/scala/org/scalacheck/CogenSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/CogenSpecification.scala
@@ -7,6 +7,7 @@ import org.scalacheck.Prop.forAll
 import org.scalacheck.rng.Seed
 
 import scala.util.Try
+import scala.concurrent.duration.{Duration, FiniteDuration}
 
 object CogenSpecification extends Properties("Cogen") {
 
@@ -147,4 +148,6 @@ object CogenSpecification extends Properties("Cogen") {
   include(cogenLaws[Throwable], "cogenThrowable.")
   include(cogenLaws[Try[Int]], "cogenTry.")
   include(cogenLaws[Seq[Int]], "cogenSeq.")
+  include(cogenLaws[Duration], "cogenDuration.")
+  include(cogenLaws[FiniteDuration], "cogenFiniteDuration.")
 }

--- a/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
@@ -374,4 +374,25 @@ object GenSpecification extends Properties("Gen") {
 
   property("negative generators are negative") =
     Prop.forAll(Gen.negNum[Int]) { n => n < 0 }
+
+  property("finite duration values are valid") =
+    // just make sure it constructs valid finite values that don't throw exceptions
+    Prop.forAll(Gen.finiteDuration) { _.isFinite }
+
+  property("duration values are valid") =
+    // just make sure it constructs valid values that don't throw exceptions
+    Prop.forAll(Gen.duration) { _ => true }
+
+  property("choose finite duration values are within range") = {
+    val g = for {
+      a <- Gen.finiteDuration
+      b <- Gen.finiteDuration
+    } yield if (a < b) (a, b) else (b, a)
+
+    Prop.forAll(g){ case (low, high) =>
+      Prop.forAll(Gen.choose(low, high)){ d =>
+        d >= low && d <= high
+      }
+    }
+  }
 }

--- a/src/main/scala/org/scalacheck/Arbitrary.scala
+++ b/src/main/scala/org/scalacheck/Arbitrary.scala
@@ -12,6 +12,7 @@ package org.scalacheck
 import language.higherKinds
 import concurrent.Future
 import scala.util.{Failure, Success, Try}
+import scala.concurrent.duration.{Duration, FiniteDuration}
 
 import util.{FreqMap, Buildable}
 import util.SerializableCanBuildFroms._
@@ -254,6 +255,19 @@ private[scalacheck] sealed trait ArbitraryLowPriority {
     // XXX TODO - restore BigInt and BigDecimal
     // Arbitrary(oneOf(arbBigInt.arbitrary :: (arbs map (_.arbitrary) map toNumber) : _*))
   }
+
+  /** Arbitrary instance of FiniteDuration */
+  implicit lazy val arbFiniteDuration: Arbitrary[FiniteDuration] =
+    Arbitrary(Gen.finiteDuration)
+
+  /**
+   * Arbitrary instance of Duration.
+   *
+   * In addition to `FiniteDuration` values, this can generate `Duration.Inf`,
+   * `Duration.MinusInf`, and `Duration.Undefined`.
+   */
+  implicit lazy val arbDuration: Arbitrary[Duration] =
+    Arbitrary(Gen.duration)
 
   /** Generates an arbitrary property */
   implicit lazy val arbProp: Arbitrary[Prop] = {


### PR DESCRIPTION
This adds `Gen`, `Arbitrary`, and `Shrink` instances for both `Duration`
and `FiniteDuration`. It also adds a `Choose` instance for
`FiniteDuration`.