### PR TITLE
Reduce the frequency of None in Option Gen

### DIFF
--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -485,7 +485,7 @@ object Gen extends GenArities{
 
   /** Makes a generator result optional. Either `Some(T)` or `None` will be provided. */
   def option[T](g: Gen[T]): Gen[Option[T]] =
-    oneOf[Option[T]](some(g), None)
+    frequency(1 -> const(None), 9 -> some(g))
 
   /** A generator that returns `Some(T)` */
   def some[T](g: Gen[T]): Gen[Option[T]] =


### PR DESCRIPTION
The idea here is that if you are generating 100 values, it's probably
not that useful for 50 of them to be the same (None). Having a 50%
chance of None is especially problematic when a data structure has
several nested Option fields, in which case it becomes pretty unlikely
that any non-None values are generated for the innermost Option field.

I've arbitrarily chosen a 10% None frequency here, but feel free to
recommend other values that may be better.