### PR TITLE
Fixes #290 (deadlock under 2.12 during property initialization)

### DIFF
--- a/jvm/src/test/scala/org/scalacheck/LazyPropertiesSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/LazyPropertiesSpecification.scala
@@ -1,0 +1,26 @@
+/*-------------------------------------------------------------------------*\
+**  ScalaCheck                                                             **
+**  Copyright (c) 2007-2016 Rickard Nilsson. All rights reserved.          **
+**  http://www.scalacheck.org                                              **
+**                                                                         **
+**  This software is released under the terms of the Revised BSD License.  **
+**  There is NO WARRANTY. See the file LICENSE for the full text.          **
+\*------------------------------------------------------------------------ */
+
+package org.scalacheck
+
+object LazyPropertiesSpecification extends Properties("Properties.lazy registration") {
+
+  property("properties registered lazily") = {
+    var evaluated = false
+    val p = new Properties("P") {
+      property("p") = {
+        evaluated = true
+        Prop.proved
+      }
+    }
+    evaluated == false
+  }
+
+}
+

--- a/src/main/scala/org/scalacheck/Prop.scala
+++ b/src/main/scala/org/scalacheck/Prop.scala
@@ -43,7 +43,7 @@ sealed abstract class Prop extends Serializable {
     for(r1 <- this; r2 <- p) yield f(r1,r2)
 
   /** Convenience method that checks this property with the given parameters
-   *  and reports the result on the console. Should only be used when running 
+   *  and reports the result on the console. Should only be used when running
    *  tests interactively within the Scala REPL.*/
   def check(prms: Test.Parameters): Unit = Test.check(
     if(prms.testCallback.isInstanceOf[ConsoleReporter]) prms
@@ -52,16 +52,16 @@ sealed abstract class Prop extends Serializable {
   )
 
   /** Convenience method that checks this property with the given parameters
-   *  and reports the result on the console. Should only be used when running 
-   *  tests interactively within the Scala REPL. 
+   *  and reports the result on the console. Should only be used when running
+   *  tests interactively within the Scala REPL.
    *
    *  The default test parameters
    *  ([[Test.Parameters.default]]) are used for the check. */
   def check: Unit = check(Test.Parameters.default)
 
   /** Convenience method that checks this property and reports the result
-   *  on the console. Should only be used when running 
-   *  tests interactively within the Scala REPL. 
+   *  on the console. Should only be used when running
+   *  tests interactively within the Scala REPL.
    *
    *  The provided argument should be a function that takes
    *  the default test parameters ([[Test.Parameters.default]])
@@ -299,10 +299,6 @@ object Prop {
 
   /** Create a property from a boolean value */
   def apply(b: Boolean): Prop = if(b) proved else falsified
-
-  /** Create a prop that evaluates the by-name argument on each application. */
-  def suspend(p: => Prop): Prop = apply(prms => p(prms))
-
 
   // Implicits
 

--- a/src/main/scala/org/scalacheck/Prop.scala
+++ b/src/main/scala/org/scalacheck/Prop.scala
@@ -300,6 +300,9 @@ object Prop {
   /** Create a property from a boolean value */
   def apply(b: Boolean): Prop = if(b) proved else falsified
 
+  /** Create a prop that evaluates the by-name argument on each application. */
+  def suspend(p: => Prop): Prop = apply(prms => p(prms))
+
 
   // Implicits
 

--- a/src/main/scala/org/scalacheck/Properties.scala
+++ b/src/main/scala/org/scalacheck/Properties.scala
@@ -98,7 +98,7 @@ class Properties(val name: String) {
       props += ((name+"."+propName, p))
     }
     def update(propName: String, p: => Prop) = {
-      props += ((name+"."+propName, Prop.suspend(p)))
+      props += ((name+"."+propName, Prop.delay(p)))
     }
   }
 

--- a/src/main/scala/org/scalacheck/Properties.scala
+++ b/src/main/scala/org/scalacheck/Properties.scala
@@ -93,7 +93,13 @@ class Properties(val name: String) {
    *  }}}
    */
   sealed class PropertySpecifier() {
-    def update(propName: String, p: Prop) = props += ((name+"."+propName, p))
+    // TODO: Delete this in 1.14 -- kept for binary compat with 1.13.3 and prior
+    protected def update(propName: String, p: Prop) = {
+      props += ((name+"."+propName, p))
+    }
+    def update(propName: String, p: => Prop) = {
+      props += ((name+"."+propName, Prop.suspend(p)))
+    }
   }
 
   lazy val property = new PropertySpecifier()


### PR DESCRIPTION
Fixes #290 by making property registration lazy.

Mima passes against 1.13.1 so this is safe to release in 1.13.4.

Review by @rickynils.