### PR TITLE
Make Gen.identifier properly respect current size

### DIFF
--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -721,10 +721,12 @@ object Gen extends GenArities{
 
   /** Generates a string that starts with a lower-case alpha character,
    *  and only contains alphanumerical characters */
-  def identifier: Gen[String] = (for {
-    c <- alphaLowerChar
-    cs <- listOf(alphaNumChar)
-  } yield (c::cs).mkString)
+  def identifier: Gen[String] = Gen.sized { size =>
+    for {
+      c <- alphaLowerChar
+      cs <- Gen.resize(size - 1, listOf(alphaNumChar))
+    } yield (c :: cs).mkString
+  }
 
   /** Generates a string of digits */
   def numStr: Gen[String] =


### PR DESCRIPTION
When generating the tail of the string reduce the size by one to account for the first character of the generated string.  Otherwise it might generate a string that's one character longer than the current generator size.

Got bitten by this when generating values for an external service that limits the size of certain parameters.

I'm not sure whether this change is entirely correct.  What if the current size is zero?  This change would pass a negative number to the subgenerator.  But can that even happen?