### PR TITLE
Enable more compiler warnings, apply respective fixes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val isRelease = false
 lazy val travisCommit = Option(System.getenv().get("TRAVIS_COMMIT"))
 
 lazy val scalaVersionSettings = Seq(
-  scalaVersion := "2.12.0",
+  scalaVersion := "2.12.1",
   crossScalaVersions := Seq("2.10.6", "2.11.8", scalaVersion.value)
 )
 
@@ -50,9 +50,27 @@ lazy val sharedSettings = MimaSettings.settings ++ scalaVersionSettings ++ Seq(
 
   javacOptions += "-Xmx1024M",
 
-  scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature"),
+  scalacOptions ++= Seq(
+    "-deprecation",
+    "-encoding", "UTF-8",
+    "-feature",
+    "-unchecked",
+    "-Xfatal-warnings",
+    "-Xlint",
+    "-Xfuture",
+    "-Yno-adapted-args",
+    "-Ywarn-dead-code",
+    "-Ywarn-inaccessible",
+    "-Ywarn-nullary-override",
+    "-Ywarn-nullary-unit",
+    "-Ywarn-numeric-widen") ++ {
+    scalaBinaryVersion.value match {
+      case "2.10" => Nil
+      case _ => Seq("-Ywarn-infer-any", "-Ywarn-unused-import")
+    }
+  },
 
-  scalacOptions in (Compile,doc) += "-Xfatal-warnings",
+  scalacOptions in Test ~= (_ filterNot (_ == "-Xfatal-warnings")),
 
   //mimaPreviousArtifacts := (
   //  if (CrossVersion isScalaApiCompatible scalaVersion.value)

--- a/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
@@ -60,7 +60,7 @@ object GenSpecification extends Properties("Gen") {
 
   property("lzy") = forAll((g: Gen[Int]) => lzy(g) == g)
 
-  property("wrap") = forAll((g: Gen[Int]) => wrap(g) == g)
+  property("wrap") = forAll((g: Gen[Int]) => delay(g) == g)
 
   property("delay") = forAll((g: Gen[Int]) => delay(g) == g)
 
@@ -299,7 +299,7 @@ object GenSpecification extends Properties("Gen") {
     const(5), const(6), const(7), const(8),
     const(9)
   )) {
-    _ == (1,2,3,4,5,6,7,8,9)
+    _ == ((1,2,3,4,5,6,7,8,9))
   }
 
   //// See https://github.com/rickynils/scalacheck/issues/79
@@ -366,7 +366,7 @@ object GenSpecification extends Properties("Gen") {
     Prop.forAllNoShrink(Gen.choose(1000000, 2000000)) { n =>
       var i = 0
       var sum = 0d
-      var seed = rng.Seed(n)
+      var seed = rng.Seed(n.toLong)
       while (i < n) {
         val (d,s1) = seed.double
         sum += d
@@ -382,7 +382,7 @@ object GenSpecification extends Properties("Gen") {
     Prop.forAllNoShrink(Gen.choose(1000000, 2000000)) { n =>
       var i = 0
       var sum = 0d
-      var seed = rng.Seed(n)
+      var seed = rng.Seed(n.toLong)
       while (i < n) {
         val (l,s1) = seed.long
         sum += math.abs(l).toDouble * scale

--- a/jvm/src/test/scala/org/scalacheck/SerializabilitySpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/SerializabilitySpecification.scala
@@ -4,8 +4,6 @@ import java.io.{ ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream,
 
 import Prop.proved
 
-import util.SerializableCanBuildFroms._
-
 object SerializabilitySpecification extends Properties("Serializability") {
 
   // adapted from https://github.com/milessabin/shapeless/blob/6b870335c219d59079b46eddff15028332c0c294/core/jvm/src/test/scala/shapeless/serialization.scala#L42-L62

--- a/jvm/src/test/scala/org/scalacheck/TestSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/TestSpecification.scala
@@ -13,7 +13,6 @@ import Gen._
 import Prop._
 import Test._
 import Arbitrary._
-import collection.mutable.ListBuffer
 
 object TestSpecification extends Properties("Test") {
 
@@ -29,7 +28,7 @@ object TestSpecification extends Properties("Test") {
 
   val shrinked = forAll( (t: (Int,Int,Int)) => false )
 
-  val propException = forAll { n:Int => throw new java.lang.Exception; true }
+  val propException = forAll { n:Int => throw new java.lang.Exception }
 
   val undefinedInt = for{
     n <- arbitrary[Int]

--- a/jvm/src/test/scala/org/scalacheck/examples/StringUtils.scala
+++ b/jvm/src/test/scala/org/scalacheck/examples/StringUtils.scala
@@ -10,7 +10,6 @@
 package org.scalacheck.example
 
 import org.scalacheck._
-import Gen.{listOf, alphaStr, numChar}
 
 object StringUtils extends Properties("Examples.StringUtils") {
 

--- a/src/main/scala/org/scalacheck/Arbitrary.scala
+++ b/src/main/scala/org/scalacheck/Arbitrary.scala
@@ -14,7 +14,7 @@ import concurrent.Future
 import scala.util.{Failure, Success, Try}
 import scala.concurrent.duration.{Duration, FiniteDuration}
 
-import util.{FreqMap, Buildable}
+import util.Buildable
 import util.SerializableCanBuildFroms._
 
 
@@ -69,7 +69,6 @@ object Arbitrary extends ArbitraryLowPriority with ArbitraryArities {
 /** separate trait to have same priority as ArbitraryArities */
 private[scalacheck] sealed trait ArbitraryLowPriority {
   import Gen.{const, choose, sized, frequency, oneOf, buildableOf, resize}
-  import collection.{immutable, mutable}
 
   /** Creates an Arbitrary instance */
   def apply[T](g: => Gen[T]): Arbitrary[T] = new Arbitrary[T] {
@@ -216,7 +215,7 @@ private[scalacheck] sealed trait ArbitraryLowPriority {
         mc <- genMathContext0
         n <- long
         d <- long
-      } yield BigDecimal(n, 0, mc) / d
+      } yield BigDecimal(n, 0, mc) / d.toDouble
 
     val genMathContext: Gen[MathContext] =
       oneOf(UNLIMITED, DECIMAL32, DECIMAL64, DECIMAL128)

--- a/src/main/scala/org/scalacheck/Cogen.scala
+++ b/src/main/scala/org/scalacheck/Cogen.scala
@@ -10,12 +10,10 @@
 package org.scalacheck
 
 import language.higherKinds
-import language.implicitConversions
 import scala.annotation.tailrec
 import scala.collection.immutable.BitSet
 import scala.util.{Failure, Success, Try}
 import scala.concurrent.duration.{Duration, FiniteDuration}
-import Arbitrary.arbitrary
 import java.math.BigInteger
 import rng.Seed
 

--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -642,7 +642,7 @@ object Gen extends GenArities{
     }
     gen { (p, seed0) =>
       new R[Stream[T]] {
-        val result: Option[Stream[T]] = Some(unfold(seed0)(s => Some(g.pureApply(p, s), s.next)))
+        val result: Option[Stream[T]] = Some(unfold(seed0)(s => Some(g.pureApply(p, s) -> s.next)))
         val seed: Seed = seed0.next
       }
     }
@@ -691,7 +691,7 @@ object Gen extends GenArities{
   /** Takes a function and returns a generator that generates arbitrary
    *  results of that function by feeding it with arbitrarily generated input
    *  parameters. */
-  def resultOf[T,R](f: T => R)(implicit a: Arbitrary[T]): Gen[R] =
+  def resultOf[T,R0](f: T => R0)(implicit a: Arbitrary[T]): Gen[R0] =
     arbitrary[T] map f
 
   /** Creates a Function0 generator. */

--- a/src/main/scala/org/scalacheck/Prop.scala
+++ b/src/main/scala/org/scalacheck/Prop.scala
@@ -13,7 +13,7 @@ import language.implicitConversions
 import language.reflectiveCalls
 
 import rng.Seed
-import util.{Pretty, FreqMap, Buildable, ConsoleReporter}
+import util.{Pretty, ConsoleReporter}
 import scala.annotation.tailrec
 
 /** Helper class to satisfy ScalaJS compilation. Do not use this directly,
@@ -26,8 +26,7 @@ sealed class PropFromFun(f: Gen.Parameters => Prop.Result) extends Prop {
 @Platform.JSExportDescendentObjects
 sealed abstract class Prop extends Serializable { self =>
 
-  import Prop.{Result, Proof, True, False, Exception, Undecided,
-    provedToTrue, secure, mergeRes}
+  import Prop.{Result, True, False, Undecided, provedToTrue, mergeRes}
   import Gen.Parameters
 
   def apply(prms: Parameters): Result
@@ -74,7 +73,7 @@ sealed abstract class Prop extends Serializable { self =>
    *
    *  The default test parameters
    *  ([[Test.Parameters.default]]) are used for the check. */
-  def check: Unit = check(Test.Parameters.default)
+  def check(): Unit = check(Test.Parameters.default)
 
   /** Convenience method that checks this property and reports the result
    *  on the console. Should only be used when running
@@ -169,7 +168,7 @@ sealed abstract class Prop extends Serializable { self =>
 
 object Prop {
 
-  import Gen.{fail, frequency, oneOf, Parameters}
+  import Gen.{fail, Parameters}
   import Arbitrary.{arbitrary}
   import Shrink.{shrink}
 
@@ -321,7 +320,7 @@ object Prop {
 
   /** A collection of property operators on `Any` values.
    *  Import [[Prop.AnyOperators]] to make the operators available. */
-  class ExtendedAny[T <% Pretty](x: => T) {
+  class ExtendedAny[T](x: => T)(implicit ev: T => Pretty) {
     /** See [[Prop.imply]] */
     def imply(f: PartialFunction[T,Prop]) = Prop.imply(x,f)
     /** See [[Prop.iff]] */
@@ -350,7 +349,7 @@ object Prop {
   /** Implicit method that makes a number of property operators on values of
    * type `Any` available in the current scope.
    * See [[Prop.ExtendedAny]] for documentation on the operators. */
-  implicit def AnyOperators[T <% Pretty](x: => T) = new ExtendedAny[T](x)
+  implicit def AnyOperators[T](x: => T)(implicit ev: T => Pretty) = new ExtendedAny[T](x)
 
   /** Implicit method that makes a number of property operators on boolean
    * values available in the current scope. See [[Prop.ExtendedBoolean]] for
@@ -449,7 +448,7 @@ object Prop {
     try { x; false } catch { case e if c.isInstance(e) => true }
 
   /** Collect data for presentation in test report */
-  def collect[T, P <% Prop](f: T => P): T => Prop = t => Prop { prms =>
+  def collect[T, P](f: T => P)(implicit ev: P => Prop): T => Prop = t => Prop { prms =>
     val prop = f(t)
     prop(prms).collect(t)
   }
@@ -469,7 +468,7 @@ object Prop {
 
   /** Wraps and protects a property, turning exceptions thrown
    *  by the property into test failures. */
-  def secure[P <% Prop](p: => P): Prop =
+  def secure[P](p: => P)(implicit ev: P => Prop): Prop =
     try (p: Prop) catch { case e: Throwable => exception(e) }
 
   /** Wraps a property to delay its evaluation. The given parameter is

--- a/src/main/scala/org/scalacheck/Shrink.scala
+++ b/src/main/scala/org/scalacheck/Shrink.scala
@@ -13,7 +13,6 @@ import language.higherKinds
 
 import util.Buildable
 import util.SerializableCanBuildFroms._
-import scala.collection.{ JavaConversions => jcl }
 import scala.concurrent.duration.{Duration, FiniteDuration}
 
 sealed abstract class Shrink[T] extends Serializable {
@@ -29,7 +28,6 @@ object Shrink extends ShrinkLowPriority {
 
   import Stream.{cons, empty}
   import scala.collection._
-  import java.util.ArrayList
 
   /** Interleaves two streams */
   private def interleave[T](xs: Stream[T], ys: Stream[T]): Stream[T] =
@@ -235,7 +233,7 @@ object Shrink extends ShrinkLowPriority {
 }
 
 final class ShrinkIntegral[T](implicit ev: Integral[T]) extends Shrink[T] {
-  import ev.{ fromInt, lt, gteq, quot, negate, equiv, zero, one }
+  import ev.{ fromInt, gteq, quot, negate, equiv, zero, one }
 
   val two = fromInt(2)
 

--- a/src/main/scala/org/scalacheck/Test.scala
+++ b/src/main/scala/org/scalacheck/Test.scala
@@ -309,7 +309,7 @@ object Test {
     import params._
     assertParams(params)
 
-    val iterations = math.ceil(minSuccessfulTests / (workers: Double))
+    val iterations = math.ceil(minSuccessfulTests / workers.toDouble)
     val sizeStep = (maxSize-minSize) / (iterations*workers)
     var stop = false
     //val seed = p.fixedSeed.getOrElse(rng.Seed.random)
@@ -325,7 +325,7 @@ object Test {
       def isExhausted = d > minSuccessfulTests * maxDiscardRatio
 
       while(!stop && res == null && n < iterations) {
-        val size = (minSize: Double) + (sizeStep * (workerIdx + (workers*(n+d))))
+        val size = minSize.toDouble + (sizeStep * (workerIdx + (workers*(n+d))))
         val propRes = p(genPrms.withSize(size.round.toInt))
         fm = if(propRes.collected.isEmpty) fm else fm + propRes.collected
         propRes.status match {

--- a/src/main/scala/org/scalacheck/util/Buildable.scala
+++ b/src/main/scala/org/scalacheck/util/Buildable.scala
@@ -9,8 +9,6 @@
 
 package org.scalacheck.util
 
-import language.higherKinds
-
 import collection.{ Map => _, _ }
 import generic.CanBuildFrom
 

--- a/src/main/scala/org/scalacheck/util/CmdLineParser.scala
+++ b/src/main/scala/org/scalacheck/util/CmdLineParser.scala
@@ -10,7 +10,6 @@
 package org.scalacheck.util
 
 import scala.collection.Set
-import org.scalacheck.Test
 
 private[scalacheck] trait CmdLineParser {
 
@@ -51,7 +50,7 @@ private[scalacheck] trait CmdLineParser {
     if (s != null && s.matches("[0987654321]+\\.?[0987654321]*")) Some(s.toFloat)
     else None
 
-  def printHelp = {
+  def printHelp(): Unit = {
     println("Available options:")
     opts.foreach { opt =>
       println("  " + opt.names.map("-"+_).mkString(", ") + ": " + opt.help)

--- a/src/main/scala/org/scalacheck/util/ConsoleReporter.scala
+++ b/src/main/scala/org/scalacheck/util/ConsoleReporter.scala
@@ -10,7 +10,7 @@
 package org.scalacheck.util
 
 import Pretty.{Params, pretty, format}
-import org.scalacheck.{Prop, Properties, Test}
+import org.scalacheck.Test
 
 /** A [[org.scalacheck.Test.TestCallback]] implementation that prints
  *  test results directly to the console. This is the callback used

--- a/src/main/scala/org/scalacheck/util/FreqMap.scala
+++ b/src/main/scala/org/scalacheck/util/FreqMap.scala
@@ -50,9 +50,9 @@ sealed trait FreqMap[T] extends Serializable {
 
   def getCounts: List[(T,Int)] = underlying.toList.sortBy(-_._2)
 
-  def getRatio(t: T) = for(c <- getCount(t)) yield (c: Float)/total
+  def getRatio(t: T) = for(c <- getCount(t)) yield c.toFloat/total
 
-  def getRatios = for((t,c) <- getCounts) yield (t, (c: Float)/total)
+  def getRatios = for((t,c) <- getCounts) yield (t, c.toFloat/total)
 
   override def toString = underlying.toString
 }

--- a/src/main/scala/org/scalacheck/util/Pretty.scala
+++ b/src/main/scala/org/scalacheck/util/Pretty.scala
@@ -34,7 +34,7 @@ object Pretty {
 
   def apply(f: Params => String): Pretty = new Pretty { def apply(p: Params) = f(p) }
 
-  def pretty[T <% Pretty](t: T, prms: Params): String = {
+  def pretty[T](t: T, prms: Params)(implicit ev: T => Pretty): String = {
     val p = (t: Pretty) match {
       case null => prettyAny(null)
       case p => p
@@ -42,7 +42,7 @@ object Pretty {
     p(prms)
   }
 
-  def pretty[T <% Pretty](t: T): String = pretty(t, defaultParams)
+  def pretty[T](t: T)(implicit ev: T => Pretty): String = pretty(t, defaultParams)
 
   implicit def strBreak(s1: String) = new {
     def /(s2: String) = if(s2 == "") s1 else s1+"\n"+s2

--- a/src/test/scala/org/scalacheck/PropSpecification.scala
+++ b/src/test/scala/org/scalacheck/PropSpecification.scala
@@ -12,19 +12,14 @@ package org.scalacheck
 import Prop.{
   forAll, falsified, undecided, exception, passed, proved, all,
   atLeastOne, sizedProp, someFailing, noneFailing, Undecided, False, True,
-  Exception, Proof, within, throws, BooleanOperators, secure, delay, lzy
+  Exception, Proof, throws, BooleanOperators, secure, delay, lzy
 }
-import Gen.{
-  const, fail, frequency, oneOf, choose, listOf, listOfN,
-  Parameters
-}
-import java.util.concurrent.atomic.AtomicBoolean
+import Gen.{ const, fail, oneOf, listOf, Parameters }
 
 object PropSpecification extends Properties("Prop") {
 
   def propException(): Prop = {
     throw new java.lang.Exception("exception")
-    passed
   }
 
   property("Prop.==> undecided") = forAll { p1: Prop =>

--- a/src/test/scala/org/scalacheck/examples/MathSpec.scala
+++ b/src/test/scala/org/scalacheck/examples/MathSpec.scala
@@ -5,7 +5,7 @@ import org.scalacheck.Prop.{forAll, BooleanOperators}
 object MathSpec extends org.scalacheck.Properties("Math") {
   property("sqrt") = forAll { n: Int =>
     (n >= 0) ==> {
-      val m = math.sqrt(n)
+      val m = math.sqrt(n.toDouble)
       math.round(m*m) == n
     }   
   }


### PR DESCRIPTION
In the process of (temporarily) internalizing a sub-set of scalacheck into my project in order to be able to the use the current 1.14 branch I discovered that the current sources produce quite a few compiler warnings that can easily be fixed.

This PR takes these changes upstream.

Most changes don't affect the public API, but in one case they do:
In accordance with `-Ywarn-nullary-unit` the formerly nullary `Test.check` method has now received an empty parameter list.
Since the public API will be broken anyway with 1.14 this change should be ok.