### PR TITLE
Create UTF-8 generators

### DIFF
--- a/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
@@ -231,6 +231,10 @@ object GenSpecification extends Properties("Gen") {
 
   property("alphaNumChar") = forAll(alphaNumChar)(_.isLetterOrDigit)
 
+  property("utf8Char") = forAll(utf8Char)(_.isValidChar)
+
+  property("utf8PrintableChar") = forAll(utf8PrintableChar)(_.isValidChar)
+
   property("identifier") = forAll(identifier) { s =>
     s.length > 0 && s(0).isLetter && s(0).isLower &&
     s.forall(_.isLetterOrDigit)
@@ -254,6 +258,14 @@ object GenSpecification extends Properties("Gen") {
 
   property("alphaNumStr") = forAll(alphaNumStr) { s =>
     s.length >= 0 && s.forall(_.isLetterOrDigit)
+  }
+
+  property("utf8Str") = forAll(utf8Str) { s =>
+    s.length >= 0 && s.forall(_.isValidChar)
+  }
+
+  property("utf8PrintableStr") = forAll(utf8PrintableStr) { s =>
+    s.length >= 0 && s.forall(_.isValidChar)
   }
 
   // BigDecimal generation is tricky; just ensure that the generator gives

--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -716,6 +716,11 @@ object Gen extends GenArities{
   /** Generates an alphanumerical character */
   def alphaNumChar = frequency((1,numChar), (9,alphaChar))
 
+  /** Generates a UTF-8 character, with extra weighting for printable characters */
+  def utf8Char: Gen[Char] = chooseNum(0, 255, 32 to 126:_*).map(_.toChar)
+
+  /** Generates a UTF-8 printable character */
+  def utf8PrintableChar: Gen[Char] = choose(32.toChar, 126.toChar)
 
   //// String Generators ////
 
@@ -745,6 +750,14 @@ object Gen extends GenArities{
   /** Generates a string of alphanumerical characters */
   def alphaNumStr: Gen[String] =
     listOf(alphaNumChar).map(_.mkString)
+
+  /** Generates a string of UTF-8 characters, with extra weighting for printable characters */
+  def utf8Str: Gen[String] =
+    listOf(utf8Char).map(_.mkString)
+
+  /** Generates a string of UTF-8 printable characters */
+  def utf8PrintableStr: Gen[String] =
+    listOf(utf8PrintableChar).map(_.mkString)
 
 
   //// Number Generators ////


### PR DESCRIPTION
Scalacheck is really great, but it would be nice if I could generate more realistic strings. So I've created 2 new generators for `Char` and `String`:
* one for printable characters only
* another for all UTF-8 characters with weighting on printable characters
Let me know if they seem suitable or need some alteration or better documentation.