### PR TITLE
Create ascii generators

### DIFF
--- a/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
@@ -231,6 +231,19 @@ object GenSpecification extends Properties("Gen") {
 
   property("alphaNumChar") = forAll(alphaNumChar)(_.isLetterOrDigit)
 
+  property("asciiChar") = forAll(asciiChar)(_.isValidChar)
+
+  property("asciiPrintableChar") = forAll(asciiPrintableChar) { ch =>
+    val charType = Character.getType(ch)
+    Character.isLetterOrDigit(ch) || Character.isSpaceChar(ch) ||
+      charType == Character.CONNECTOR_PUNCTUATION || charType == Character.DASH_PUNCTUATION ||
+      charType == Character.START_PUNCTUATION || charType == Character.END_PUNCTUATION ||
+      charType == Character.INITIAL_QUOTE_PUNCTUATION || charType == Character.FINAL_QUOTE_PUNCTUATION ||
+      charType == Character.OTHER_PUNCTUATION ||
+      charType == Character.MATH_SYMBOL || charType == Character.CURRENCY_SYMBOL ||
+      charType == Character.MODIFIER_SYMBOL || charType == Character.OTHER_SYMBOL
+  }
+
   property("identifier") = forAll(identifier) { s =>
     s.length > 0 && s(0).isLetter && s(0).isLower &&
     s.forall(_.isLetterOrDigit)
@@ -254,6 +267,23 @@ object GenSpecification extends Properties("Gen") {
 
   property("alphaNumStr") = forAll(alphaNumStr) { s =>
     s.length >= 0 && s.forall(_.isLetterOrDigit)
+  }
+
+  property("asciiStr") = forAll(asciiStr) { s =>
+    s.length >= 0 && s.forall(_.isValidChar)
+  }
+
+  property("asciiPrintableStr") = forAll(asciiPrintableStr) { s =>
+    s.length >= 0 && s.forall { ch =>
+      val charType = Character.getType(ch)
+      Character.isLetterOrDigit(ch) || Character.isSpaceChar(ch) ||
+        charType == Character.CONNECTOR_PUNCTUATION || charType == Character.DASH_PUNCTUATION ||
+        charType == Character.START_PUNCTUATION || charType == Character.END_PUNCTUATION ||
+        charType == Character.INITIAL_QUOTE_PUNCTUATION || charType == Character.FINAL_QUOTE_PUNCTUATION ||
+        charType == Character.OTHER_PUNCTUATION ||
+        charType == Character.MATH_SYMBOL || charType == Character.CURRENCY_SYMBOL ||
+        charType == Character.MODIFIER_SYMBOL || charType == Character.OTHER_SYMBOL
+    }
   }
 
   // BigDecimal generation is tricky; just ensure that the generator gives

--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -716,6 +716,11 @@ object Gen extends GenArities{
   /** Generates an alphanumerical character */
   def alphaNumChar = frequency((1,numChar), (9,alphaChar))
 
+  /** Generates a ASCII character, with extra weighting for printable characters */
+  def asciiChar: Gen[Char] = chooseNum(0, 127, 32 to 126:_*).map(_.toChar)
+
+  /** Generates a ASCII printable character */
+  def asciiPrintableChar: Gen[Char] = choose(32.toChar, 126.toChar)
 
   //// String Generators ////
 
@@ -745,6 +750,14 @@ object Gen extends GenArities{
   /** Generates a string of alphanumerical characters */
   def alphaNumStr: Gen[String] =
     listOf(alphaNumChar).map(_.mkString)
+
+  /** Generates a string of ASCII characters, with extra weighting for printable characters */
+  def asciiStr: Gen[String] =
+    listOf(asciiChar).map(_.mkString)
+
+  /** Generates a string of ASCII printable characters */
+  def asciiPrintableStr: Gen[String] =
+    listOf(asciiPrintableChar).map(_.mkString)
 
 
   //// Number Generators ////


### PR DESCRIPTION
Scalacheck is really great, but it would be nice if I could generate more realistic strings. So I've created 2 new generators for Char and String:
* one for printable characters only
* another for all ASCII characters with weighting on printable characters
Let me know if they seem suitable or need some alteration or better documentation.