### PR TITLE
Fix retrying code in doPureApply.

### DIFF
--- a/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
@@ -24,6 +24,20 @@ object GenSpecification extends Properties("Gen") {
     arbitrary[Long] flatMap Seed.apply
   )
 
+  property("pureApply #300") = {
+    def testCase[A](gen: Gen[A]): Prop =
+      sizedProp { sz =>
+        val g = Gen.function1(gen)(Cogen[Int])
+        if (sz > 0) forAll(g) { f => f(999); true } else Prop(true)
+      }
+    val p0 = testCase(arbitrary[Int].suchThat(_ != 0))
+    val p1 = testCase(arbitrary[String].suchThat(_ != ""))
+    val p2 = testCase(arbitrary[Boolean].suchThat(_ != false))
+    val p3 = testCase(arbitrary[List[Double]].suchThat(_ != Nil))
+    val p4 = testCase(oneOf(1, 2, 3, 4, 5).suchThat(_ == 1))
+    p0 && p1 && p2 && p3 && p4
+  }
+
   property("sequence") =
     forAll(listOf(frequency((10,const(arbitrary[Int])),(1,const(fail)))))(l =>
       (someFailing(l) && (sequence[List[Int],Int](l) == fail)) ||

--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -53,7 +53,7 @@ sealed abstract class Gen[+T] extends Serializable { self =>
   def doPureApply(p: Gen.Parameters, seed: Seed, retries: Int = 100): Gen.R[T] = {
     @tailrec def loop(r: Gen.R[T], i: Int): Gen.R[T] =
       if (r.retrieve.isDefined) r
-      else if (i > 0) loop(r, i - 1)
+      else if (i > 0) loop(doApply(p, r.seed), i - 1)
       else throw new Gen.RetrievalError()
     loop(doApply(p, seed), retries)
   }


### PR DESCRIPTION
(Backport of #301.)

This commit fixes a bug pointed out by @alexarchambault. When
constructing an `A => B` value from `Cogen[A]` and `Gen[B]`, we need
to be able to reliably generate a `B` value given a `Seed`. The
`doPureApply` method was given the ability to retry -- but
unfortunately, it used the same result value (with the same seed)
instead of trying a new one, defeating the retry code.

This commit fixes that problem. It adds tests to ensure that filtered
generators that can also produce real values can be used with
Gen.function1. (If a generator can never produce values it will still
be a problem.)

Fixes #300.