### PR TITLE
Improve the seed interface a bit.

### DIFF
--- a/jvm/src/test/scala/org/scalacheck/rng/SeedSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/rng/SeedSpecification.scala
@@ -12,6 +12,7 @@ package org.scalacheck
 import Prop.forAll
 import Arbitrary.arbitrary
 import rng.Seed
+import scala.util.Try
 
 object SeedSpecification extends Properties("Seed") {
 
@@ -69,11 +70,11 @@ object SeedSpecification extends Properties("Seed") {
 
   property("base-64 serialization works") =
     forAll { (s0: Seed) =>
-      s0 == Seed.fromBase64(s0.toBase64)
+      Try(s0) == Seed.fromBase64(s0.toBase64)
     }
 
   property("illegal seeds throw exceptions") =
     forAll { (s: String) =>
-      scala.util.Try(Seed.fromBase64(s)).isFailure
+      Seed.fromBase64(s).isFailure
     }
 }

--- a/src/main/scala/org/scalacheck/Properties.scala
+++ b/src/main/scala/org/scalacheck/Properties.scala
@@ -107,7 +107,7 @@ class Properties(val name: String) {
       val fullName = s"$name.$propName"
       optSeed match {
         case Some(encodedSeed) =>
-          val seed = Seed.fromBase64(encodedSeed)
+          val seed = Seed.fromBase64(encodedSeed).get
           props += ((fullName, Prop.delay(p).useSeed(fullName, seed)))
         case None =>
           props += ((fullName, Prop.delay(p).viewSeed(fullName)))

--- a/src/main/scala/org/scalacheck/rng/Seed.scala
+++ b/src/main/scala/org/scalacheck/rng/Seed.scala
@@ -10,10 +10,10 @@ import scala.util.Try
  * http://burtleburtle.net/bob/rand/smallprng.html
  */
 sealed abstract class Seed extends Serializable {
-  val a: Long
-  val b: Long
-  val c: Long
-  val d: Long
+  protected val a: Long
+  protected val b: Long
+  protected val c: Long
+  protected val d: Long
 
   /**
    * Generate a Base-64 representation of this seed.

--- a/src/main/scala/org/scalacheck/rng/Seed.scala
+++ b/src/main/scala/org/scalacheck/rng/Seed.scala
@@ -99,7 +99,7 @@ sealed abstract class Seed extends Serializable {
 object Seed {
 
   private case class apply(a: Long, b: Long, c: Long, d: Long) extends Seed {
-    override def toString: String = toBase64
+    override def toString: String = s"""Seed.fromBase64("$toBase64")"""
   }
 
   /** Generate a deterministic seed. */

--- a/src/main/scala/org/scalacheck/rng/Seed.scala
+++ b/src/main/scala/org/scalacheck/rng/Seed.scala
@@ -1,4 +1,8 @@
-package org.scalacheck.rng
+package org.scalacheck
+package rng
+
+import scala.annotation.tailrec
+import scala.util.Try
 
 /**
  * Simple RNG by Bob Jenkins:
@@ -6,10 +10,10 @@ package org.scalacheck.rng
  * http://burtleburtle.net/bob/rand/smallprng.html
  */
 sealed abstract class Seed extends Serializable {
-  protected val a: Long
-  protected val b: Long
-  protected val c: Long
-  protected val d: Long
+  val a: Long
+  val b: Long
+  val c: Long
+  val d: Long
 
   /**
    * Generate a Base-64 representation of this seed.
@@ -95,7 +99,7 @@ sealed abstract class Seed extends Serializable {
 object Seed {
 
   private case class apply(a: Long, b: Long, c: Long, d: Long) extends Seed {
-    override def toString: String = "Seed(%016x, %016x, %016x, %016x)" format (a, b, c, d)
+    override def toString: String = toBase64
   }
 
   /** Generate a deterministic seed. */
@@ -141,14 +145,11 @@ object Seed {
    * This method will throw an IllegalArgumentException if parsing
    * fails.
    */
-  def fromBase64(s: String): Seed = {
+  def fromBase64(s: String): Try[Seed] = {
     def fail(s: String): Nothing = throw new IllegalArgumentException(s)
-    if (s.length != 44) fail(s"wrong Base64 length: $s")
-    if (s.charAt(43) != '=') fail(s"wrong Base64 format: $s")
-    if (s.charAt(42) == '=') fail(s"wrong Base64 format: $s")
 
     def dec(c: Char): Long =
-      if ('A' <= c && c <= 'Z') (c - 'A').toLong
+      if      ('A' <= c && c <= 'Z') (c - 'A').toLong
       else if ('a' <= c && c <= 'z') ((c - 'a') + 26).toLong
       else if ('0' <= c && c <= '9') ((c - '0') + 52).toLong
       else if (c == '-') 62L
@@ -156,7 +157,7 @@ object Seed {
       else fail(s"illegal Base64 character: $c")
 
     val longs = new Array[Long](4)
-    def decode(x: Long, shift: Int, i: Int, j: Int): Seed =
+    @tailrec def decode(x: Long, shift: Int, i: Int, j: Int): Seed =
       if (i >= 43) {
         Seed.fromLongs(longs(0), longs(1), longs(2), longs(3))
       } else {
@@ -169,7 +170,13 @@ object Seed {
           decode(b >>> sh, 6 - sh, i + 1, j + 1)
         }
       }
-    decode(0L, 0, 0, 0)
+
+    Try {
+      if (s.length != 44) fail(s"wrong Base64 length: $s")
+      if (s.charAt(43) != '=') fail(s"wrong Base64 format: $s")
+      if (s.charAt(42) == '=') fail(s"wrong Base64 format: $s")
+      decode(0L, 0, 0, 0)
+    }
   }
 
   /** Generate a random seed. */


### PR DESCRIPTION
The major wart this fixes is the return value of fromBase64. This
method now returns Try[Seed], since it is expected to deal with
arbitrary user input.

This commit also improves the string representation of seeds, and
makes the seed internals public (which should be fine, since the seed
is immutable).

Finally this commit includes a few assorted fixes.