### PR TITLE
Gen.pick defect

### DIFF
--- a/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
@@ -200,6 +200,18 @@ object GenSpecification extends Properties("Gen") {
     }
   }
 
+  property("distributed pick") = {
+    val lst = (0 to 7).toIterable
+    val n = 2
+    forAll(pick(n, lst)) { xs: Seq[Int] =>
+      xs.map { x: Int =>
+        Prop.collect(x) {
+          xs.size == n
+        }
+      } reduce (_ && _)
+    }
+  }
+
   property("numChar") = forAll(numChar)(_.isDigit)
 
   property("calendar") = forAll(calendar) { cal =>

--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -681,7 +681,7 @@ object Gen extends GenArities{
           buf += t
         } else {
           val (x, s) = seed.long
-          val i = (x & 0x7fffffff).toInt % n
+          val i = (x & 0x7fffffff).toInt % count
           if (i < n) buf(i) = t
           seed = s
         }


### PR DESCRIPTION
This one-liner should fix the issue in #332 about the distribution of `Gen.pick`.

I've included a unit test in 57b6fb4  that uses `Prop.collect` to show the problem.  However, it's not a unit test worth keeping, IMO.  It's just for showing the problem.  There may be a better test, but it's not the one.  It's not general enough, and it's a bit too noisey:

```
+ Gen.distributed pick: OK, passed 100 tests.
> Collected test data: 
 42% 7, 6
 25% 7, 5
 17% 4, 7
 7% 3, 7
 4% 7, 2
 3% 7, 1
 2% 0, 7
```

It shows the distribution gets a lot better with the fix in 2ee295d:

```
+ Gen.distributed pick: OK, passed 100 tests.
> Collected test data: 
 7% 6, 1
 7% 6, 4
 6% 3, 5
 6% 5, 2
 5% 2, 1
 5% 6, 3
 5% 0, 4
 5% 0, 3
 4% 2, 3
 4% 0, 1
 4% 7, 2
 4% 7, 6
 3% 6, 2
 3% 3, 7
 3% 7, 5
 3% 4, 3
 3% 7, 1
 3% 4, 2
 3% 4, 1
 3% 0, 7
 2% 0, 2
 2% 5, 4
 2% 5, 1
 2% 0, 5
 2% 7, 4
 2% 0, 6
 1% 6, 5
 1% 3, 1
```

Thanks goes to @alexeyr for pointing out the reservoir sampling algorithm as the solution.