### PR TITLE
Cross compile to Scala Native

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: scala
+dist: trusty
 script: ./tools/travis-script.sh
 after_success: ./tools/travis-deploy.sh
 branches:
@@ -27,4 +28,11 @@ env:
     - PLATFORM=jvm SBT_PARALLEL=true  WORKERS=4 DEPLOY=false
     - PLATFORM=jvm SBT_PARALLEL=false WORKERS=4 DEPLOY=false
     - PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true
-sudo: false
+
+matrix:
+  include:
+    - scala: 2.11.11
+      before_script:
+        - curl https://raw.githubusercontent.com/scala-native/scala-native/v0.3.0/bin/travis_setup.sh | bash -x
+      sudo: required
+      env: PLATFORM=native SBT_PARALLEL=true  WORKERS=1 DEPLOY=true

--- a/build.sbt
+++ b/build.sbt
@@ -136,7 +136,7 @@ lazy val native = project.in(file("native"))
     doc in Compile := (doc in Compile in jvm).value,
     scalaVersion := "2.11.11",
     libraryDependencies ++= Seq(
-      "org.scala-native" %% "test-interface_native0.3.0-SNAPSHOT" % "0.3.0-SNAPSHOT"
+      "org.scala-native" %% "test-interface_native0.3" % "0.3.1"
     )
   )
   .enablePlugins(ScalaNativePlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ lazy val sharedSettings = MimaSettings.settings ++ scalaVersionSettings ++ Seq(
   version := {
     val suffix =
       if (isRelease) ""
-      else /*travisCommit.map("-" + _.take(7)).getOrElse("") +*/ "-SNAPSHOT"
+      else travisCommit.map("-" + _.take(7)).getOrElse("") + "-SNAPSHOT"
     versionNumber + suffix
   },
 
@@ -136,7 +136,6 @@ lazy val native = project.in(file("native"))
     doc in Compile := (doc in Compile in jvm).value,
     scalaVersion := "2.11.11",
     libraryDependencies ++= Seq(
-      "org.scala-sbt" % "test-interface" % "1.0",
       "org.scala-native" %% "test-interface_native0.3.0-SNAPSHOT" % "0.3.0-SNAPSHOT"
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ lazy val sharedSettings = MimaSettings.settings ++ scalaVersionSettings ++ Seq(
   version := {
     val suffix =
       if (isRelease) ""
-      else travisCommit.map("-" + _.take(7)).getOrElse("") + "-SNAPSHOT"
+      else /*travisCommit.map("-" + _.take(7)).getOrElse("") +*/ "-SNAPSHOT"
     versionNumber + suffix
   },
 

--- a/build.sbt
+++ b/build.sbt
@@ -137,7 +137,7 @@ lazy val native = project.in(file("native"))
     scalaVersion := "2.11.11",
     libraryDependencies ++= Seq(
       "org.scala-sbt" % "test-interface" % "1.0",
-      "org.scala-native" %% "scalanative-stubs_native0.3.0-SNAPSHOT" % "0.3.0-SNAPSHOT" % "provided"
+      "org.scala-native" %% "test-interface_native0.3.0-SNAPSHOT" % "0.3.0-SNAPSHOT"
     )
   )
   .enablePlugins(ScalaNativePlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -129,3 +129,15 @@ lazy val jvm = project.in(file("jvm"))
   .settings(
     libraryDependencies += "org.scala-sbt" %  "test-interface" % "1.0"
   )
+
+lazy val native = project.in(file("native"))
+  .settings(sharedSettings: _*)
+  .settings(
+    doc in Compile := (doc in Compile in jvm).value,
+    scalaVersion := "2.11.11",
+    libraryDependencies ++= Seq(
+      "org.scala-sbt" % "test-interface" % "1.0",
+      "org.scala-native" %% "scalanative-stubs_native0.3.0-SNAPSHOT" % "0.3.0-SNAPSHOT" % "provided"
+    )
+  )
+  .enablePlugins(ScalaNativePlugin)

--- a/native/src/main/scala/org/scalacheck/Platform.scala
+++ b/native/src/main/scala/org/scalacheck/Platform.scala
@@ -28,7 +28,7 @@ private[scalacheck] object Platform {
     org.scalajs.testinterface.TestUtils.newInstance(name, loader)(args)
 
   // We don't need those annotation in Native, and they have been deprecated.
-  // We use `Unit` instead of the definition in Native because `-Xfatal-warnings`
+  // We use `String` instead of the definition in Native because `-Xfatal-warnings`
   // is set.
   type JSExportDescendentObjects = String
   type JSExportDescendentClasses = String

--- a/native/src/main/scala/org/scalacheck/Platform.scala
+++ b/native/src/main/scala/org/scalacheck/Platform.scala
@@ -1,0 +1,33 @@
+/*-------------------------------------------------------------------------*\
+**  ScalaCheck                                                             **
+**  Copyright (c) 2007-2017 Rickard Nilsson. All rights reserved.          **
+**  http://www.scalacheck.org                                              **
+**                                                                         **
+**  This software is released under the terms of the Revised BSD License.  **
+**  There is NO WARRANTY. See the file LICENSE for the full text.          **
+\*------------------------------------------------------------------------ */
+
+package org.scalacheck
+
+import Test._
+
+private[scalacheck] object Platform {
+
+  def runWorkers(
+    params: Parameters,
+    workerFun: Int => Result,
+    stop: () => Unit
+  ): Result = {
+    workerFun(0)
+  }
+
+  def loadModule(name: String, loader: ClassLoader): AnyRef =
+    org.scalajs.testinterface.TestUtils.loadModule(name, loader)
+
+  def newInstance(name: String, loader: ClassLoader)(args: Seq[AnyRef]): AnyRef =
+    org.scalajs.testinterface.TestUtils.newInstance(name, loader)(args)
+
+  type JSExportDescendentObjects = scala.scalajs.js.annotation.JSExportDescendentObjects
+
+  type JSExportDescendentClasses = scala.scalajs.js.annotation.JSExportDescendentClasses
+}

--- a/native/src/main/scala/org/scalacheck/Platform.scala
+++ b/native/src/main/scala/org/scalacheck/Platform.scala
@@ -27,7 +27,9 @@ private[scalacheck] object Platform {
   def newInstance(name: String, loader: ClassLoader)(args: Seq[AnyRef]): AnyRef =
     org.scalajs.testinterface.TestUtils.newInstance(name, loader)(args)
 
-  type JSExportDescendentObjects = scala.scalajs.js.annotation.JSExportDescendentObjects
-
-  type JSExportDescendentClasses = scala.scalajs.js.annotation.JSExportDescendentClasses
+  // We don't need those annotation in Native, and they have been deprecated.
+  // We use `Unit` instead of the definition in Native because `-Xfatal-warnings`
+  // is set.
+  type JSExportDescendentObjects = String
+  type JSExportDescendentClasses = String
 }

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -4,6 +4,6 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.13")
 
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.3.0-SNAPSHOT")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.3.1")
 
 scalacOptions += "-deprecation"

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -4,4 +4,6 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.13")
 
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.3.0-SNAPSHOT")
+
 scalacOptions += "-deprecation"

--- a/src/test/scala/org/scalacheck/PropSpecification.scala
+++ b/src/test/scala/org/scalacheck/PropSpecification.scala
@@ -144,8 +144,8 @@ object PropSpecification extends Properties("Prop") {
   }
 
   property("throws") = throws(classOf[java.lang.Exception]) {
-    val s: String = null
-    s.length
+    val it: Iterator[Int] = Iterator.empty
+    it.next()
   }
 
   property("sizedProp") = {


### PR DESCRIPTION
The next release of Scala Native is coming soon, and it will add support for test frameworks using sbt's test interface (scala-native/scala-native#755). While implementing the test interface, I cross compiled scalacheck to Scala Native.

Here are the changes that I did to get it to cross compile and work with Scala Native. Obviously, Scala Native 0.3.0 is not released yet, and you'll need to build Scala Native locally to test it. Here's what it looks like: https://travis-ci.org/Duhemm/scala-native/jobs/242582498#L2665-L2697

## How to try it

 - Here's the branch that adds the test interface to Scala Native: https://github.com/Duhemm/scala-native/tree/topic/test-interface (use that instead of Scala Native's `master` branch if you happen to read that before the aforementioned PR is merged).
 - Here's how to get started with Scala Native: http://www.scala-native.org/en/latest/user/setup.html

After your system is set up, you can build Scala Native locally:

```
$ git clone https://github.com/scala-native/scala-native.git
$ cd scala-native
$ sbt rebuild
```

Then, build and `publishLocal`ly this PR. You can use the published artifact in a Scala Native project [as shown here](https://github.com/Duhemm/scala-native/blob/8939e764fff8faae8a77df9b872df1414dc403c1/build.sbt#L430). Write your tests as usual and run them using `test` in sbt.

It would be great if we could get this PR in soon after Scala Native is released (I'll update it with the correct version numbers). Do you see things that need to be addressed in this PR while we wait for the next release of Scala Native?