### PR TITLE
Scala.js version bump for 1.13.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -97,7 +97,10 @@ lazy val js = project.in(file("js"))
   .settings(sharedSettings: _*)
   .settings(
     scalaJSStage in Global := FastOptStage,
-    libraryDependencies += "org.scala-js" %% "scalajs-test-interface" % scalaJSVersion
+    libraryDependencies += "org.scala-js" %% "scalajs-test-interface" % scalaJSVersion,
+    // this will work for the Scala.js 0.6.x series but will eventually need
+    // to be addressed properly, as per http://www.scala-js.org/news/2017/03/21/announcing-scalajs-0.6.15/
+    scalacOptions += "-P:scalajs:suppressExportDeprecations"
   )
   .enablePlugins(ScalaJSPlugin)
 

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -2,6 +2,6 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.14")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.13")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.17")
 
 scalacOptions += "-deprecation"


### PR DESCRIPTION
this is for Scala 2.13.0-M1 friendliness; older Scala.js versions
weren't published for 2.13.0-M1