### PR TITLE
Add Scala 2.13.0-M2 suppport

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,9 @@ notifications:
 
 scala:
   - 2.10.6
-  - 2.11.8
-  - 2.12.0
+  - 2.11.11
+  - 2.12.3
+  - 2.13.0-M2
 jdk:
   - oraclejdk8
 env:

--- a/build.sbt
+++ b/build.sbt
@@ -10,8 +10,8 @@ lazy val isRelease = false
 lazy val travisCommit = Option(System.getenv().get("TRAVIS_COMMIT"))
 
 lazy val scalaVersionSettings = Seq(
-  scalaVersion := "2.12.1",
-  crossScalaVersions := Seq("2.10.6", "2.11.8", scalaVersion.value)
+  scalaVersion := "2.12.3",
+  crossScalaVersions := Seq("2.10.6", "2.11.11", "2.13.0-M2", scalaVersion.value)
 )
 
 lazy val sharedSettings = MimaSettings.settings ++ scalaVersionSettings ++ Seq(
@@ -56,7 +56,6 @@ lazy val sharedSettings = MimaSettings.settings ++ scalaVersionSettings ++ Seq(
     "-feature",
     "-unchecked",
     "-Xfatal-warnings",
-    "-Xlint",
     "-Xfuture",
     "-Yno-adapted-args",
     "-Ywarn-dead-code",
@@ -65,8 +64,9 @@ lazy val sharedSettings = MimaSettings.settings ++ scalaVersionSettings ++ Seq(
     "-Ywarn-nullary-unit",
     "-Ywarn-numeric-widen") ++ {
     scalaBinaryVersion.value match {
-      case "2.10" => Nil
-      case _ => Seq("-Ywarn-infer-any", "-Ywarn-unused-import")
+      case "2.10" => Seq("-Xlint")
+      case "2.11" => Seq("-Xlint", "-Ywarn-infer-any", "-Ywarn-unused-import")
+      case _      => Seq("-Xlint:-unused", "-Ywarn-infer-any", "-Ywarn-unused:imports,-patvars,-implicits,-locals,-privates,-params")
     }
   },
 

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -2,6 +2,6 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.14")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.17")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.19")
 
 scalacOptions += "-deprecation"


### PR DESCRIPTION
Here is the fix for #349. Also I've upgraded Scala 2.11 to 2.11.11, Scala 2.12 to 2.12.3 and ScalaJS to 0.6.19. 

It looks like there are some new checks for Xlint:unused since Scala 2.12.2. I didn't try to fix all of these errors (there are number of unused parameters and private methods) but just turned these warnings off for Scala >= 2.12.