### PR TITLE
Support for adjustable-width ConsoleReporter output

### DIFF
--- a/src/main/scala/org/scalacheck/util/ConsoleReporter.scala
+++ b/src/main/scala/org/scalacheck/util/ConsoleReporter.scala
@@ -17,19 +17,20 @@ import org.scalacheck.Test
  *  ScalaCheck's command line test runner, and when you run
  *  `org.scalacheck.Prop.check()`.
  */
-class ConsoleReporter(val verbosity: Int) extends Test.TestCallback {
+class ConsoleReporter(val verbosity: Int, val columnWidth: Int)
+  extends Test.TestCallback {
 
   private val prettyPrms = Params(verbosity)
 
-  override def onTestResult(name: String, res: Test.Result) = {
+  override def onTestResult(name: String, res: Test.Result): Unit = {
     if(verbosity > 0) {
       if(name == "") {
         val s = (if(res.passed) "+ " else "! ") + pretty(res, prettyPrms)
-        printf("\r%s\n", format(s, "", "", 75))
+        printf("\r%s\n", format(s, "", "", columnWidth))
       } else {
         val s = (if(res.passed) "+ " else "! ") + name + ": " +
           pretty(res, prettyPrms)
-        printf("\r%s\n", format(s, "", "", 75))
+        printf("\r%s\n", format(s, "", "", columnWidth))
       }
     }
   }
@@ -39,7 +40,9 @@ class ConsoleReporter(val verbosity: Int) extends Test.TestCallback {
 object ConsoleReporter {
 
   /** Factory method, creates a ConsoleReporter with the
-   *  the given verbosity */
-  def apply(verbosity: Int = 0) = new ConsoleReporter(verbosity)
+   *  the given verbosity and wraps output at the given column width
+   *  (use 0 for unlimited width). */
+  def apply(verbosity: Int = 0, columnWidth: Int = 75) =
+    new ConsoleReporter(verbosity, columnWidth)
 
 }

--- a/src/main/scala/org/scalacheck/util/Pretty.scala
+++ b/src/main/scala/org/scalacheck/util/Pretty.scala
@@ -52,7 +52,7 @@ object Pretty {
     else s + List.fill(length-s.length)(c).mkString
 
   def break(s: String, lead: String, length: Int): String =
-    if(s.length <= length) s
+    if(s.length <= length || length <= 0) s
     else s.substring(0, length) / break(lead+s.substring(length), lead, length)
 
   def format(s: String, lead: String, trail: String, width: Int) =


### PR DESCRIPTION
Relates to this StackOverflow question:

https://stackoverflow.com/questions/30970017/how-to-increase-the-char-column-width-for-the-scalacheck-console-output

I also desired this option, primarily to avoid going nuts when printing a stack trace.