### PR TITLE
Drop Ordering bound on the values in cogenMap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ target
 
 /examples/simple-sbt/project/
 /examples/simple-sbt/target/
+
+# Intellij
+.idea

--- a/src/main/scala/org/scalacheck/Cogen.scala
+++ b/src/main/scala/org/scalacheck/Cogen.scala
@@ -126,8 +126,8 @@ object Cogen extends CogenArities with CogenLowPriority {
   implicit def cogenSet[A: Cogen: Ordering]: Cogen[Set[A]] =
     Cogen.it(_.toVector.sorted.iterator)
 
-  implicit def cogenMap[K: Cogen: Ordering, V: Cogen: Ordering]: Cogen[Map[K, V]] =
-    Cogen.it(_.toVector.sorted.iterator)
+  implicit def cogenMap[K: Cogen: Ordering, V: Cogen]: Cogen[Map[K, V]] =
+    Cogen.it(_.toVector.sortBy(_._1).iterator)
 
   implicit def cogenFunction0[Z: Cogen]: Cogen[() => Z] =
     Cogen[Z].contramap(f => f())


### PR DESCRIPTION
It's safe to sort only by the keys, because they are distinct.

Fixes #356