### PR TITLE
add proxied generator to access Parameters and Seed within a Gen

### DIFF
--- a/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
@@ -136,6 +136,13 @@ object GenSpecification extends Properties("Gen") {
 
   property("sized") = forAll((g: Gen[Int]) => sized(i => g) == g)
 
+  property("proxied") =
+    Prop.forAll { (p1: Gen.Parameters, seed: Long, g: Gen[Int]) =>
+        val s1 = rng.Seed(seed)
+        Gen.proxied((p, s) => g).apply(p1, s1) == g.apply(p1, s1)
+    }
+
+
   property("oneOf n") = forAll { (l: List[Int]) =>
     Try(oneOf(l)) match {
       case Success(g) => forAll(g)(l.contains)

--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -527,6 +527,10 @@ object Gen extends GenArities{
   def sized[T](f: Int => Gen[T]): Gen[T] =
     gen { (p, seed) => f(p.size).doApply(p, seed) }
 
+  /** Creates a generator that can access its generation parameters and seed */
+  def proxied[T](f: (P, Seed) => Gen[T]): Gen[T] =
+    gen { (p, seed) => f(p, seed).doApply(p, seed) }
+
   /** A generator that returns the current generation size */
   lazy val size: Gen[Int] = sized { sz => sz }
 


### PR DESCRIPTION
This generator will pass the Parameters and Seed supplied from the outer generator to the inner/proxied one. I needed to access the framework generated seed in one of the generators I was building it would have been useful to have this function. I'm not sure if it is really necessarily useful for anyone else. Happy to hear thoughts on this even if this PR is not merged.