### PR TITLE
Fixes the type parameter in a call to arbitrary in a property

### DIFF
--- a/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
@@ -510,7 +510,7 @@ object GenSpecification extends Properties("Gen") {
   }
 
   property("arbitrary[Boolean] is deterministic") =
-    testDeterministicGen(arbitrary[Long])
+    testDeterministicGen(arbitrary[Boolean])
 
   property("arbitrary[Long] is deterministic") =
     testDeterministicGen(arbitrary[Long])


### PR DESCRIPTION
This was probably a copy-paste error when writing properties so I believe there is no need for much discussion here.