### PR TITLE
Bump sbt to 1.0.4, update sbt-pgp

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.0.4

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.14")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 
 val scalaJSVersion =
   Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.21")


### PR DESCRIPTION
This pull request updates the build to sbt 1.x; it relies on sbt 1.0.3, which will be published shortly.
Also see:
https://github.com/sbt/sbt-standalone-build/issues/15
https://github.com/sbt/sbt/pull/3669
Please wait for 1.0.3 to be available before merging.