### PR TITLE
Prevent shrinking for listOfN

### DIFF
--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -650,9 +650,10 @@ object Gen extends GenArities{
    *  `nonEmptyContainerOf[List,T](g)`. */
   def nonEmptyListOf[T](g: => Gen[T]) = nonEmptyBuildableOf[List[T],T](g)
 
-  /** Generates a list of the given length. This method is equal to calling
-   *  `containerOfN[List,T](n,g)`. */
-  def listOfN[T](n: Int, g: Gen[T]) = buildableOfN[List[T],T](n,g)
+  /** Generates a list of the given length. This method is equivalent to calling
+   *  `containerOfN[List,T](n,g).suchThat(_.size == n)`. */
+  def listOfN[T](n: Int, g: Gen[T]) =
+    buildableOfN[List[T],T](n,g).suchThat(_.size == n)
 
   /** Generates a map of random length. The maximum length depends on the
    *  size parameter. This method is equal to calling


### PR DESCRIPTION
Add `.suchThat(_.size == n)` to `Gen` created by `listOfN` to shield the output from shrinking in case of a failure.

There are a few issues in this repository with `containerOfN` and `buildableOfN` producing containers of incorrect size. They all seem to arrive at the same conclusion: creating containers of required size is difficult in general case. However, if we know the exact container we're using, it can be trivial.

This changes the behavior of `listOfN` to agree with its doc comment: the resulting generator now produces lists of exactly the given length.