### PR TITLE
Fix import statements

### DIFF
--- a/jvm/src/test/scala/org/scalacheck/commands/CommandsSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/commands/CommandsSpecification.scala
@@ -7,9 +7,8 @@
 **  There is NO WARRANTY. See the file LICENSE for the full text.          **
 \*------------------------------------------------------------------------ */
 
-package org.scalacheck.commands
-
-import org.scalacheck._
+package org.scalacheck
+package commands
 
 object CommandsSpecification extends Properties("Commands") {
 

--- a/jvm/src/test/scala/org/scalacheck/examples/StringUtils.scala
+++ b/jvm/src/test/scala/org/scalacheck/examples/StringUtils.scala
@@ -7,9 +7,8 @@
 **  There is NO WARRANTY. See the file LICENSE for the full text.          **
 \*------------------------------------------------------------------------ */
 
-package org.scalacheck.example
-
-import org.scalacheck._
+package org.scalacheck
+package example
 
 object StringUtils extends Properties("Examples.StringUtils") {
 

--- a/src/main/scala/org/scalacheck/commands/Commands.scala
+++ b/src/main/scala/org/scalacheck/commands/Commands.scala
@@ -7,9 +7,9 @@
 **  There is NO WARRANTY. See the file LICENSE for the full text.          **
 \*------------------------------------------------------------------------ */
 
-package org.scalacheck.commands
+package org.scalacheck
+package commands
 
-import org.scalacheck._
 import scala.util.{Try, Success, Failure}
 
 /** An API for stateful testing in ScalaCheck.

--- a/src/main/scala/org/scalacheck/util/ConsoleReporter.scala
+++ b/src/main/scala/org/scalacheck/util/ConsoleReporter.scala
@@ -7,10 +7,10 @@
 **  There is NO WARRANTY. See the file LICENSE for the full text.          **
 \*------------------------------------------------------------------------ */
 
-package org.scalacheck.util
+package org.scalacheck
+package util
 
 import Pretty.{Params, pretty, format}
-import org.scalacheck.Test
 
 /** A [[org.scalacheck.Test.TestCallback]] implementation that prints
  *  test results directly to the console. This is the callback used by

--- a/src/test/scala/org/scalacheck/examples/Examples.scala
+++ b/src/test/scala/org/scalacheck/examples/Examples.scala
@@ -1,6 +1,5 @@
-package org.scalacheck.examples
-
-import org.scalacheck.{Prop, Properties}
+package org.scalacheck
+package examples
 
 object Examples extends Properties("Examples") {
 
@@ -32,8 +31,6 @@ object Examples extends Properties("Examples") {
       age <- choose(1,100)
     } yield Person(firstName, lastName, age)
   }
-
-  import org.scalacheck.Arbitrary
 
   implicit val arbPerson = Arbitrary(genPerson)
 

--- a/src/test/scala/org/scalacheck/util/Pretty.scala
+++ b/src/test/scala/org/scalacheck/util/Pretty.scala
@@ -7,9 +7,8 @@
 **  There is NO WARRANTY. See the file LICENSE for the full text.          **
 \*------------------------------------------------------------------------ */
 
-package org.scalacheck.util
-
-import org.scalacheck.Properties
+package org.scalacheck
+package util
 
 object PrettySpecification extends Properties("Pretty") {
 


### PR DESCRIPTION
There a few cases in the code where a wildcard import statement is
used unnecessarily:

    import org.scalacheck._

Which could be avoided by just using multiple package declarations.

For example,

    package org.scalacheck
    package util

Instead of 

    package org.scalacheck.util

This change **in total** is more deletions than additions in lines of codes, and should avoid people copy-pasting this anti-pattern any further in the code tree.