### PR TITLE
Fix package statements

### DIFF
--- a/examples/scalajs/src/test/scala/example/ScalaJSExampleTest.scala
+++ b/examples/scalajs/src/test/scala/example/ScalaJSExampleTest.scala
@@ -1,4 +1,4 @@
-package example
+package org.scalacheck.example
 
 import org.scalacheck._
 

--- a/src/main/scala/org/scalacheck/rng/Seed.scala
+++ b/src/main/scala/org/scalacheck/rng/Seed.scala
@@ -1,5 +1,4 @@
-package org.scalacheck
-package rng
+package org.scalacheck.rng
 
 import scala.annotation.tailrec
 import scala.util.Try

--- a/src/test/scala/org/scalacheck/util/BuildableSpecification.scala
+++ b/src/test/scala/org/scalacheck/util/BuildableSpecification.scala
@@ -7,8 +7,9 @@
 **  There is NO WARRANTY. See the file LICENSE for the full text.          **
 \*------------------------------------------------------------------------ */
 
-package org.scalacheck
-package util
+package org.scalacheck.util
+
+import org.scalacheck._
 
 import language.higherKinds
 


### PR DESCRIPTION
There a few cases in the code where a wildcard import statement is
not used:

    import org.scalacheck._

Which could be promoted by just using one package declarations per
file.

For example,

    package org.scalacheck.util

This is the contrapositive of #373, since it was rejected.