### PR TITLE
Fix Gen.choose for Double infinity

### DIFF
--- a/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
@@ -118,7 +118,7 @@ object GenSpecification extends Properties("Gen") {
 
   import Double.{MinValue, MaxValue}
   property("choose-large-double") = forAll(choose(MinValue, MaxValue)) { x =>
-    MinValue <= x && x <= MaxValue
+    MinValue <= x && x <= MaxValue && !x.isNaN
   }
 
   import Double.{NegativeInfinity, PositiveInfinity}

--- a/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
@@ -123,6 +123,12 @@ object GenSpecification extends Properties("Gen") {
 
   import Double.{NegativeInfinity, PositiveInfinity}
   property("choose-infinite-double") = {
+    forAll(Gen.choose(NegativeInfinity, PositiveInfinity)) { x =>
+      NegativeInfinity <= x && x <= PositiveInfinity && !x.isNaN
+    }
+  }
+
+  property("choose-infinite-double-fix-zero-defect-379") = {
     Prop.forAllNoShrink(listOfN(3, choose(NegativeInfinity, PositiveInfinity))) { xs =>
       xs.exists(_ != 0d)
     }

--- a/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
@@ -121,6 +121,13 @@ object GenSpecification extends Properties("Gen") {
     MinValue <= x && x <= MaxValue
   }
 
+  import Double.{NegativeInfinity, PositiveInfinity}
+  property("choose-infinite-double") = {
+    Prop.forAllNoShrink(listOfN(3, choose(NegativeInfinity, PositiveInfinity))) { xs =>
+      xs.exists(_ != 0d)
+    }
+  }
+
   property("choose-xmap") = {
     implicit val chooseDate: Choose[Date] =
       Choose.xmap[Long, Date](new Date(_), _.getTime)

--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -411,10 +411,10 @@ object Gen extends GenArities{
         def choose(low: Double, high: Double) =
           if (low > high) throw new IllegalBoundsError(low, high)
           else if (low == Double.NegativeInfinity)
-            frequency(1 -> Double.NegativeInfinity,
+            frequency(1 -> const(Double.NegativeInfinity),
                       9 -> choose(Double.MinValue, high))
           else if (high == Double.PositiveInfinity)
-            frequency(1 -> Double.PositiveInfinity,
+            frequency(1 -> const(Double.PositiveInfinity),
                       9 -> choose(low, Double.MaxValue))
           else gen(chDbl(low,high))
       }

--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -377,10 +377,6 @@ object Gen extends GenArities{
       val d = h - l
       if (d < 0) {
         throw new IllegalBoundsError(l, h)
-      } else if (l == Double.NegativeInfinity) {
-        chDbl(Double.MinValue, h)(p, seed)
-      } else if (h == Double.PositiveInfinity) {
-        chDbl(l, Double.MaxValue)(p, seed)
       } else if (d > Double.MaxValue) {
         val (x, seed2) = seed.long
         if (x < 0) chDbl(l, 0d)(p, seed2) else chDbl(0d, h)(p, seed2)
@@ -414,6 +410,12 @@ object Gen extends GenArities{
       new Choose[Double] {
         def choose(low: Double, high: Double) =
           if (low > high) throw new IllegalBoundsError(low, high)
+          else if (low == Double.NegativeInfinity)
+            frequency(1 -> Double.NegativeInfinity,
+                      9 -> choose(Double.MinValue, high))
+          else if (high == Double.PositiveInfinity)
+            frequency(1 -> Double.PositiveInfinity,
+                      9 -> choose(low, Double.MaxValue))
           else gen(chDbl(low,high))
       }
 

--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -377,6 +377,10 @@ object Gen extends GenArities{
       val d = h - l
       if (d < 0) {
         throw new IllegalBoundsError(l, h)
+      } else if (l == Double.NegativeInfinity) {
+        chDbl(Double.MinValue, h)(p, seed)
+      } else if (h == Double.PositiveInfinity) {
+        chDbl(l, Double.MaxValue)(p, seed)
       } else if (d > Double.MaxValue) {
         val (x, seed2) = seed.long
         if (x < 0) chDbl(l, 0d)(p, seed2) else chDbl(0d, h)(p, seed2)


### PR DESCRIPTION
I was able to verify #379 with the following test that checks that there is at least one non-zero value in a sample of three:

```scala
    import Double.{NegativeInfinity, PositiveInfinity}
    property("choose-infinite-double") = {
      Prop.forAllNoShrink(listOfN(3, choose(NegativeInfinity, PositiveInfinity))) { xs =>
        xs.exists(_ != 0d)
      }
    }
```

Here it is failing currently:

    [info] ! Gen.choose-infinite-double: Falsified after 0 passed tests.
    [info] > ARG_0: List("0.0", "0.0", "0.0")

The test assumes that flipping a `Double.MaxValue`-sided coin and getting a zero three times in a row is impossible.  Someone may need to check my math on that.

    scala> 2 * math.pow(Long.MaxValue.toDouble, -3d)
    res0: Double = 2.5489470578119236E-57

The fix here just substitutes `Double.MinValue` for `Double.NegativeInfinity` and `Double.MaxValue` for `Double.PositiveInfinity` in the internal function `Gen.Choose.chDbl`, _and also adds_ the special constants `Double.NegativeInfinity` and `Double.PositiveInfinity` at a frequency of 10% (for both respectively).