### PR TITLE
Update to the latest travis_setup.sh for Scala Native

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
   include:
     - scala: 2.11.11
       before_script:
-        - curl https://raw.githubusercontent.com/scala-native/scala-native/21539aa97947f767afcd85b5c2fb3c0262b2d301/bin/travis_setup.sh | bash -x
+        - curl https://raw.githubusercontent.com/scala-native/scala-native/master/scripts/travis_setup.sh | bash -x
       sudo: required
       env: PLATFORM=native SBT_PARALLEL=true  WORKERS=1 DEPLOY=true
   exclude:


### PR DESCRIPTION
[Recent PR](https://github.com/scala-native/scala-native/pull/1195) changed the location of the travis setup script within a Scala Native repo. This PR updates travis build to point to the new location.