### PR TITLE
Disable -params in 2.12 and later

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,7 +66,7 @@ lazy val sharedSettings = MimaSettings.settings ++ scalaVersionSettings ++ Seq(
     scalaBinaryVersion.value match {
       case "2.10" => Seq("-Xlint")
       case "2.11" => Seq("-Xlint", "-Ywarn-infer-any", "-Ywarn-unused-import")
-      case _      => Seq("-Xlint:-unused", "-Ywarn-infer-any", "-Ywarn-unused:imports,-patvars,-implicits,-locals,-privates,-params")
+      case _      => Seq("-Xlint:-unused", "-Ywarn-infer-any", "-Ywarn-unused:imports,-patvars,-implicits,-locals,-privates,-explicits")
     }
   },
 


### PR DESCRIPTION
Replace with `-Ywarn-unused:-implicits,-explicits`.  Note that `-implicits` was already set.

Currently, building gives a  non-fatal compiler error:

    [error] 'params' cannot be negated, it enables other arguments