### PR TITLE
Fix console scalacOptions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,7 +65,7 @@ lazy val sharedSettings = MimaSettings.settings ++ scalaVersionSettings ++ Seq(
     scalaBinaryVersion.value match {
       case "2.10" => Seq("-Xlint")
       case "2.11" => Seq("-Xlint", "-Ywarn-infer-any", "-Ywarn-unused-import")
-      case _      => Seq("-Xlint:-unused", "-Ywarn-infer-any", "-Ywarn-unused:imports,-patvars,-implicits,-locals,-privates,-explicits")
+      case _      => Seq("-Xlint:-unused", "-Ywarn-infer-any", "-Ywarn-unused-import", "-Ywarn-unused:-patvars,-implicits,-locals,-privates,-explicits")
     }
   },
 


### PR DESCRIPTION
It's not possible to hack on Scalacheck from the REPL since #353.

    sbt> jvm/console
    [info] Starting scala interpreter...

    scala> import org.scalacheck.Prop
    import org.scalacheck.Prop
    <console>:11: warning: Unused import
           import org.scalacheck.Prop
                                 ^
    error: No warnings can be incurred under -Xfatal-warnings.

    scala> Prop.passed
    <console>:12: error: not found: value Prop
           Prop.passed
           ^

On line 75 of `build.sbt`, this line is supposed to disable it, but the filter is no longer working:

```scala
scalacOptions in (Compile, console) ~= {_.filterNot("-Ywarn-unused-import" == _)},
```