### PR TITLE
Fix compilation on Java 9

### DIFF
--- a/jvm/src/main/scala/org/scalacheck/Platform.scala
+++ b/jvm/src/main/scala/org/scalacheck/Platform.scala
@@ -63,7 +63,7 @@ private[scalacheck] object Platform {
 
   def newInstance(name: String, loader: ClassLoader, paramTypes: Seq[Class[_]])(args: Seq[AnyRef]): AnyRef =
     if(!args.isEmpty) ???
-    else Class.forName(name, true, loader).newInstance.asInstanceOf[AnyRef]
+    else Class.forName(name, true, loader).getDeclaredConstructor().newInstance().asInstanceOf[AnyRef]
 
   def loadModule(name: String, loader: ClassLoader): AnyRef =
     Class.forName(name + "$", true, loader).getField("MODULE$").get(null)


### PR DESCRIPTION
Fixes #406.

This compiles on Java 9, but it doesn't seem there are tests here to verify that this change works.

Seems this code is related to running tests in sbt.  If ScalaCheck's own test suite runs, it may be proof that it works.  Running the debugger and adding a breakpoint, it does appear to be called, for what that's worth.