### PR TITLE
Fix the scaladocs of Gen.mapOf

### DIFF
--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -643,16 +643,16 @@ object Gen extends GenArities{
 
   /** Generates a map of random length. The maximum length depends on the
    *  size parameter. This method is equal to calling
-   *  <code>containerOf[Map,T,U](g)</code>. */
+   *  <code>containerOf[Map,(T,U)](g)</code>. */
   def mapOf[T,U](g: => Gen[(T,U)]) = buildableOf[Map[T,U],(T,U)](g)
 
   /** Generates a non-empty map of random length. The maximum length depends
    *  on the size parameter. This method is equal to calling
-   *  <code>nonEmptyContainerOf[Map,T,U](g)</code>. */
+   *  <code>nonEmptyContainerOf[Map,(T,U)](g)</code>. */
   def nonEmptyMap[T,U](g: => Gen[(T,U)]) = nonEmptyBuildableOf[Map[T,U],(T,U)](g)
 
   /** Generates a map with at most the given number of elements. This method
-   *  is equal to calling <code>containerOfN[Map,T,U](n,g)</code>. */
+   *  is equal to calling <code>containerOfN[Map,(T,U)](n,g)</code>. */
   def mapOfN[T,U](n: Int, g: Gen[(T,U)]) = buildableOfN[Map[T,U],(T,U)](n,g)
 
   /** Generates an infinite stream. */

--- a/src/main/scala/org/scalacheck/Prop.scala
+++ b/src/main/scala/org/scalacheck/Prop.scala
@@ -66,7 +66,7 @@ sealed abstract class Prop extends Serializable { self =>
     this
   )
 
-  /** Convenience method that checks this property with the given parameters
+  /** Convenience method that checks this property
    *  and reports the result on the console. Should only be used when running
    *  tests interactively within the Scala REPL.
    *
@@ -387,7 +387,7 @@ object Prop {
   /** A property that denotes an exception */
   lazy val exception: Prop = exception(null)
 
-  /** Create a property that compares to values. If the values aren't equal,
+  /** Create a property that compares two values. If the values aren't equal,
    * the property will fail and report that first value doesn't match the
    * expected (second) value. */
   def ?=[T](x: T, y: T)(implicit pp: T => Pretty): Prop =
@@ -397,7 +397,7 @@ object Prop {
       "Expected "+exp+" but got "+act
     }
 
-  /** Create a property that compares to values. If the values aren't equal,
+  /** Create a property that compares two values. If the values aren't equal,
    * the property will fail and report that second value doesn't match the
    * expected (first) value. */
   def =?[T](x: T, y: T)(implicit pp: T => Pretty): Prop = ?=(y, x)


### PR DESCRIPTION
The methods `containerOf`, `containerOfN`, and `nonEmptyContainerOf` all accept two type parameters, not three.