### PR TITLE
Fix Scaladoc: choose throws an exception if the range is invalid

### DIFF
--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -442,8 +442,8 @@ object Gen extends GenArities{
     }
 
   /** A generator that generates a random value in the given (inclusive)
-   *  range. If the range is invalid, the generator will not generate
-   *  any value. */
+   *  range. If the range is invalid, an IllegalBoundsError exception will be
+   *  thrown. */
   def choose[T](min: T, max: T)(implicit c: Choose[T]): Gen[T] =
     c.choose(min, max)
 


### PR DESCRIPTION
Since commit a2100f6846b047aebc490a48dda49e283b4d2fee, invalid ranges now
throw an error instead of creating empty genererators.