### PR TITLE
On check use provided parameters instead of falling back to default

### DIFF
--- a/src/main/scala/org/scalacheck/Test.scala
+++ b/src/main/scala/org/scalacheck/Test.scala
@@ -311,7 +311,6 @@ object Test {
     var stop = false
     //val seed = p.fixedSeed.getOrElse(rng.Seed.random)
     //val genPrms = Gen.Parameters.default.withInitialSeed(seed)
-    val genPrms = Gen.Parameters.default
 
     def workerFun(workerIdx: Int): Result = {
       var n = 0  // passed tests
@@ -323,7 +322,7 @@ object Test {
 
       while(!stop && res == null && n < iterations) {
         val size = minSize.toDouble + (sizeStep * (workerIdx + (workers*(n+d))))
-        val propRes = p(genPrms.withSize(size.round.toInt))
+        val propRes = p(params.withSize(size.round.toInt))
         fm = if(propRes.collected.isEmpty) fm else fm + propRes.collected
         propRes.status match {
           case Prop.Undecided =>


### PR DESCRIPTION
Apologies if current behaviour is intentional. We're currently using specs2 as our host test framework, and because it calls [Test.check](https://github.com/etorreborre/specs2/blob/8225ee5f29a176b69070e8e4dc7bada20688d93c/scalacheck/shared/src/main/scala/org/specs2/scalacheck/ScalaCheckPropertyCheck.scala#L54) ~~from the parameters provided by a [Prop apply callback](https://github.com/etorreborre/specs2/blob/8225ee5f29a176b69070e8e4dc7bada20688d93c/scalacheck/shared/src/main/scala/org/specs2/scalacheck/AsResultProp.scala#L18)~~ (EDIT: Wrong parameter type, just ignore that bit) it ends up re-setting the parameters. Specs2 is probably mis-using these scalacheck APIs, but it still seems weird to completely ignore the parameters in that function.

Thanks in advance!