### PR TITLE
work around scala/bug#11125

### DIFF
--- a/src/main/scala/org/scalacheck/util/Pretty.scala
+++ b/src/main/scala/org/scalacheck/util/Pretty.scala
@@ -56,7 +56,8 @@ object Pretty {
     else s.substring(0, length) / break(lead+s.substring(length), lead, length)
 
   def format(s: String, lead: String, trail: String, width: Int) =
-    s.lines.map(l => break(lead+l+trail, "  ", width)).mkString("\n")
+    // was just `s.lines....`, but on JDK 11 we hit scala/bug#11125
+    Predef.augmentString(s).lines.map(l => break(lead+l+trail, "  ", width)).mkString("\n")
 
   private def toStrOrNull(s: Any) = if (s == null) "null" else s.toString
 


### PR DESCRIPTION
this is for the Scala community build, where we want to be able
to build everything on JDK 11 to help test Scala

references scala/bug#11125