### PR TITLE
update Scala.js and sbt versions (on 2.13 release branch)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -131,7 +131,10 @@ lazy val js = project.in(file("js"))
   .settings(sharedSettings: _*)
   .settings(
     scalaJSStage in Global := FastOptStage,
-    libraryDependencies += "org.scala-js" %% "scalajs-test-interface" % scalaJSVersion
+    libraryDependencies += "org.scala-js" %% "scalajs-test-interface" % scalaJSVersion,
+    // because Scala.js deprecated TestUtils but we haven't worked around that yet,
+    // see https://github.com/rickynils/scalacheck/pull/435#issuecomment-430405390
+    scalacOptions ~= (_ filterNot (_ == "-Xfatal-warnings"))
   )
   .enablePlugins(ScalaJSPlugin)
 

--- a/examples/scalajs/project/build.sbt
+++ b/examples/scalajs/project/build.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.22")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.25")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.1
+sbt.version=1.2.3

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -3,7 +3,7 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.2.0")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
 
 val scalaJSVersion =
-  Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.23")
+  Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.25")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 


### PR DESCRIPTION
@rickynils hopefully this will permit publishing 1.14.0 for Scala.js
on Scala 2.13.0-M5?