### PR TITLE
Widen "oneOf" argument to "Iterable" from "Seq"

### DIFF
--- a/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
@@ -54,9 +54,14 @@ object GenSpecification extends Properties("Gen") {
     forAll(g) { n => true }
   }
 
-  property("frequency 3") = forAll(choose(0,100000)) { n =>
+  property("frequency 3") = forAll(choose(1,100000)) { n =>
     forAll(frequency(List.fill(n)((1,const(0))): _*)) { _ == 0 }
   }
+
+  property("frequency 4") =
+    Prop.throws(classOf[IllegalArgumentException]) {
+      frequency()
+    }
 
   property("lzy") = forAll((g: Gen[Int]) => lzy(g) == g)
 

--- a/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
@@ -141,6 +141,13 @@ object GenSpecification extends Properties("Gen") {
     }
   }
 
+  property("oneOf n in set") = forAll { (s: Set[Int]) =>
+    Try(oneOf(s)) match {
+      case Success(g) => forAll(g)(s.contains)
+      case Failure(_) => Prop(s.isEmpty)
+    }
+  }
+
   property("oneOf 2") = forAll { (n1:Int, n2:Int) =>
     forAll(oneOf(n1, n2)) { n => n == n1 || n == n2 }
   }

--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -520,14 +520,20 @@ object Gen extends GenArities{
   /** Creates a resized version of a generator */
   def resize[T](s: Int, g: Gen[T]) = gen((p, seed) => g.doApply(p.withSize(s), seed))
 
-  /** Picks a random value from a list */
-  def oneOf[T](xs: Seq[T]): Gen[T] =
+  /** Picks a random value from a list. */
+  def oneOf[T](xs: Iterable[T]): Gen[T] =
     if (xs.isEmpty) {
       throw new IllegalArgumentException("oneOf called on empty collection")
     } else {
       val vector = xs.toVector
       choose(0, vector.size - 1).map(vector(_))
     }
+
+  /** Picks a random value from a list.
+   *  @todo Remove this overloaded method in the next major release. See #438.
+   */
+  def oneOf[T](xs: Seq[T]): Gen[T] =
+    oneOf(xs: Iterable[T])
 
   /** Picks a random value from a list */
   def oneOf[T](t0: T, t1: T, tn: T*): Gen[T] = oneOf(t0 +: t1 +: tn)


### PR DESCRIPTION
Hi maintainers,

For convenience, we would like to use the `oneOf` combinator on sets in our tests. So we have widened the argument to `Iterable` from `Seq` and added a test. After merging, the following snippet should compile.

```scala
val set: Set[A] = ???
Gen.oneOf(set)
```

**Background.** Currently, the `oneOf` combinator is restricted to `Seq`. To use sets, there are currently two workarounds. First, we could convert it to a sequence. Second, we could use the `Gen.pick[T]` combinator. The workarounds are shown below.

```scala
val set: Set[A] = ???

// Workaround 1
Gen.oneOf(set.toSeq)

// Workaround 2
Gen.pick(1, set).map(_.head)
```

However, both of these workarounds are inconvenient if the `oneOf` combinator could be widened to accept `Iterable`.

Additionally, we noticed that the following combinators also accept `Iterable`, so we believe that this change should make the API more uniform.

- `Gen.someOf[T]`
- `Gen.atLeastOne[T]`

As a final note, the `Iterable` trait should be compatible with the Scala 2.13 collections work. :)