### PR TITLE
Deprecate forAll with Gens

### DIFF
--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -163,7 +163,7 @@ sealed abstract class Gen[+T] extends Serializable { self =>
     if (lhs == rhs) Prop.proved(prms) else Prop.falsified(prms)
   }
 
-  def !=[U](g: Gen[U]) = Prop.forAll(this)(r => Prop.forAll(g)(_ != r))
+  def !=[U](g: Gen[U]) = Prop.forAllShrink(this)(r => Prop.forAllShrink(g)(_ != r))
 
   def !==[U](g: Gen[U]) = Prop { prms =>
     // test inequality using a random seed

--- a/src/main/scala/org/scalacheck/Prop.scala
+++ b/src/main/scala/org/scalacheck/Prop.scala
@@ -747,6 +747,107 @@ object Prop {
   }
 
   /** Universal quantifier for an explicit generator. Shrinks failed arguments
+   *  with the default shrink function for the type */
+  def forAllShrink[T1,P](
+    g1: Gen[T1])(
+    f: T1 => P)(implicit
+    p: P => Prop,
+    s1: Shrink[T1],
+    pp1: T1 => Pretty
+  ): Prop = forAllShrink[T1,P](g1, shrink[T1] _)(f)
+
+  /** Universal quantifier for two explicit generators. Shrinks failed arguments
+   *  with the default shrink function for the type */
+  def forAllShrink[T1,T2,P](
+    g1: Gen[T1], g2: Gen[T2])(
+    f: (T1,T2) => P)(implicit
+    p: P => Prop,
+    s1: Shrink[T1], pp1: T1 => Pretty,
+    s2: Shrink[T2], pp2: T2 => Pretty
+  ): Prop = forAllShrink(g1)(t => forAllShrink(g2)(f(t, _:T2)))
+
+  /** Universal quantifier for three explicit generators. Shrinks failed arguments
+   *  with the default shrink function for the type */
+  def forAllShrink[T1,T2,T3,P](
+    g1: Gen[T1], g2: Gen[T2], g3: Gen[T3])(
+    f: (T1,T2,T3) => P)(implicit
+    p: P => Prop,
+    s1: Shrink[T1], pp1: T1 => Pretty,
+    s2: Shrink[T2], pp2: T2 => Pretty,
+    s3: Shrink[T3], pp3: T3 => Pretty
+  ): Prop = forAllShrink(g1)(t => forAllShrink(g2,g3)(f(t, _:T2, _:T3)))
+
+  /** Universal quantifier for four explicit generators. Shrinks failed arguments
+   *  with the default shrink function for the type */
+  def forAllShrink[T1,T2,T3,T4,P](
+    g1: Gen[T1], g2: Gen[T2], g3: Gen[T3], g4: Gen[T4])(
+    f: (T1,T2,T3,T4) => P)(implicit
+    p: P => Prop,
+    s1: Shrink[T1], pp1: T1 => Pretty,
+    s2: Shrink[T2], pp2: T2 => Pretty,
+    s3: Shrink[T3], pp3: T3 => Pretty,
+    s4: Shrink[T4], pp4: T4 => Pretty
+  ): Prop = forAllShrink(g1)(t => forAllShrink(g2,g3,g4)(f(t, _:T2, _:T3, _:T4)))
+
+  /** Universal quantifier for five explicit generators. Shrinks failed arguments
+   *  with the default shrink function for the type */
+  def forAllShrink[T1,T2,T3,T4,T5,P](
+    g1: Gen[T1], g2: Gen[T2], g3: Gen[T3], g4: Gen[T4], g5: Gen[T5])(
+    f: (T1,T2,T3,T4,T5) => P)(implicit
+    p: P => Prop,
+    s1: Shrink[T1], pp1: T1 => Pretty,
+    s2: Shrink[T2], pp2: T2 => Pretty,
+    s3: Shrink[T3], pp3: T3 => Pretty,
+    s4: Shrink[T4], pp4: T4 => Pretty,
+    s5: Shrink[T5], pp5: T5 => Pretty
+  ): Prop = forAllShrink(g1)(t => forAllShrink(g2,g3,g4,g5)(f(t, _:T2, _:T3, _:T4, _:T5)))
+
+  /** Universal quantifier for six explicit generators. Shrinks failed arguments
+   *  with the default shrink function for the type */
+  def forAllShrink[T1,T2,T3,T4,T5,T6,P](
+    g1: Gen[T1], g2: Gen[T2], g3: Gen[T3], g4: Gen[T4], g5: Gen[T5], g6: Gen[T6])(
+    f: (T1,T2,T3,T4,T5,T6) => P)(implicit
+    p: P => Prop,
+    s1: Shrink[T1], pp1: T1 => Pretty,
+    s2: Shrink[T2], pp2: T2 => Pretty,
+    s3: Shrink[T3], pp3: T3 => Pretty,
+    s4: Shrink[T4], pp4: T4 => Pretty,
+    s5: Shrink[T5], pp5: T5 => Pretty,
+    s6: Shrink[T6], pp6: T6 => Pretty
+  ): Prop = forAllShrink(g1)(t => forAllShrink(g2,g3,g4,g5,g6)(f(t, _:T2, _:T3, _:T4, _:T5, _:T6)))
+
+  /** Universal quantifier for seven explicit generators. Shrinks failed arguments
+   *  with the default shrink function for the type */
+  def forAllShrink[T1,T2,T3,T4,T5,T6,T7,P](
+    g1: Gen[T1], g2: Gen[T2], g3: Gen[T3], g4: Gen[T4], g5: Gen[T5], g6: Gen[T6], g7: Gen[T7])(
+    f: (T1,T2,T3,T4,T5,T6,T7) => P)(implicit
+    p: P => Prop,
+    s1: Shrink[T1], pp1: T1 => Pretty,
+    s2: Shrink[T2], pp2: T2 => Pretty,
+    s3: Shrink[T3], pp3: T3 => Pretty,
+    s4: Shrink[T4], pp4: T4 => Pretty,
+    s5: Shrink[T5], pp5: T5 => Pretty,
+    s6: Shrink[T6], pp6: T6 => Pretty,
+    s7: Shrink[T7], pp7: T7 => Pretty
+  ): Prop = forAllShrink(g1)(t => forAllShrink(g2,g3,g4,g5,g6,g7)(f(t, _:T2, _:T3, _:T4, _:T5, _:T6, _:T7)))
+
+  /** Universal quantifier for eight explicit generators. Shrinks failed arguments
+   *  with the default shrink function for the type */
+  def forAllShrink[T1,T2,T3,T4,T5,T6,T7,T8,P](
+    g1: Gen[T1], g2: Gen[T2], g3: Gen[T3], g4: Gen[T4], g5: Gen[T5], g6: Gen[T6], g7: Gen[T7], g8: Gen[T8])(
+    f: (T1,T2,T3,T4,T5,T6,T7,T8) => P)(implicit
+    p: P => Prop,
+    s1: Shrink[T1], pp1: T1 => Pretty,
+    s2: Shrink[T2], pp2: T2 => Pretty,
+    s3: Shrink[T3], pp3: T3 => Pretty,
+    s4: Shrink[T4], pp4: T4 => Pretty,
+    s5: Shrink[T5], pp5: T5 => Pretty,
+    s6: Shrink[T6], pp6: T6 => Pretty,
+    s7: Shrink[T7], pp7: T7 => Pretty,
+    s8: Shrink[T8], pp8: T8 => Pretty
+  ): Prop = forAllShrink(g1)(t => forAllShrink(g2,g3,g4,g5,g6,g7,g8)(f(t, _:T2, _:T3, _:T4, _:T5, _:T6, _:T7, _:T8)))
+
+  /** Universal quantifier for an explicit generator. Shrinks failed arguments
    *  with the given shrink function */
   def forAllShrink[T, P](g: Gen[T],
     shrink: T => Stream[T])(f: T => P
@@ -813,7 +914,7 @@ object Prop {
     p: P => Prop,
     s1: Shrink[T1],
     pp1: T1 => Pretty
-  ): Prop = forAllShrink[T1,P](g1, shrink[T1])(f)
+  ): Prop = forAllShrink[T1,P](g1, shrink[T1] _)(f)
 
   /** Universal quantifier for two explicit generators. Shrinks failed arguments
    *  with the default shrink function for the type */
@@ -918,7 +1019,7 @@ object Prop {
     f: A1 => P)(implicit
     p: P => Prop,
     a1: Arbitrary[A1], s1: Shrink[A1], pp1: A1 => Pretty
-  ): Prop = forAllShrink(arbitrary[A1],shrink[A1])(f andThen p)
+  ): Prop = forAllShrink(arbitrary[A1],shrink[A1] _)(f andThen p)
 
   /** Converts a function into a universally quantified property */
   def forAll[A1,A2,P] (

--- a/src/main/scala/org/scalacheck/Prop.scala
+++ b/src/main/scala/org/scalacheck/Prop.scala
@@ -806,6 +806,7 @@ object Prop {
 
   /** Universal quantifier for an explicit generator. Shrinks failed arguments
    *  with the default shrink function for the type */
+  @deprecated("Shrink will be disabled when given explicit Gen, use forAllShrink instead", "1.15.0")
   def forAll[T1,P](
     g1: Gen[T1])(
     f: T1 => P)(implicit
@@ -816,6 +817,7 @@ object Prop {
 
   /** Universal quantifier for two explicit generators. Shrinks failed arguments
    *  with the default shrink function for the type */
+  @deprecated("Shrink will be disabled when given explicit Gen, use forAllShrink instead", "1.15.0")
   def forAll[T1,T2,P](
     g1: Gen[T1], g2: Gen[T2])(
     f: (T1,T2) => P)(implicit
@@ -826,6 +828,7 @@ object Prop {
 
   /** Universal quantifier for three explicit generators. Shrinks failed arguments
    *  with the default shrink function for the type */
+  @deprecated("Shrink will be disabled when given explicit Gen, use forAllShrink instead", "1.15.0")
   def forAll[T1,T2,T3,P](
     g1: Gen[T1], g2: Gen[T2], g3: Gen[T3])(
     f: (T1,T2,T3) => P)(implicit
@@ -837,6 +840,7 @@ object Prop {
 
   /** Universal quantifier for four explicit generators. Shrinks failed arguments
    *  with the default shrink function for the type */
+  @deprecated("Shrink will be disabled when given explicit Gen, use forAllShrink instead", "1.15.0")
   def forAll[T1,T2,T3,T4,P](
     g1: Gen[T1], g2: Gen[T2], g3: Gen[T3], g4: Gen[T4])(
     f: (T1,T2,T3,T4) => P)(implicit
@@ -849,6 +853,7 @@ object Prop {
 
   /** Universal quantifier for five explicit generators. Shrinks failed arguments
    *  with the default shrink function for the type */
+  @deprecated("Shrink will be disabled when given explicit Gen, use forAllShrink instead", "1.15.0")
   def forAll[T1,T2,T3,T4,T5,P](
     g1: Gen[T1], g2: Gen[T2], g3: Gen[T3], g4: Gen[T4], g5: Gen[T5])(
     f: (T1,T2,T3,T4,T5) => P)(implicit
@@ -862,6 +867,7 @@ object Prop {
 
   /** Universal quantifier for six explicit generators. Shrinks failed arguments
    *  with the default shrink function for the type */
+  @deprecated("Shrink will be disabled when given explicit Gen, use forAllShrink instead", "1.15.0")
   def forAll[T1,T2,T3,T4,T5,T6,P](
     g1: Gen[T1], g2: Gen[T2], g3: Gen[T3], g4: Gen[T4], g5: Gen[T5], g6: Gen[T6])(
     f: (T1,T2,T3,T4,T5,T6) => P)(implicit
@@ -876,6 +882,7 @@ object Prop {
 
   /** Universal quantifier for seven explicit generators. Shrinks failed arguments
    *  with the default shrink function for the type */
+  @deprecated("Shrink will be disabled when given explicit Gen, use forAllShrink instead", "1.15.0")
   def forAll[T1,T2,T3,T4,T5,T6,T7,P](
     g1: Gen[T1], g2: Gen[T2], g3: Gen[T3], g4: Gen[T4], g5: Gen[T5], g6: Gen[T6], g7: Gen[T7])(
     f: (T1,T2,T3,T4,T5,T6,T7) => P)(implicit
@@ -891,6 +898,7 @@ object Prop {
 
   /** Universal quantifier for eight explicit generators. Shrinks failed arguments
    *  with the default shrink function for the type */
+  @deprecated("Shrink will be disabled when given explicit Gen, use forAllShrink instead", "1.15.0")
   def forAll[T1,T2,T3,T4,T5,T6,T7,T8,P](
     g1: Gen[T1], g2: Gen[T2], g3: Gen[T3], g4: Gen[T4], g5: Gen[T5], g6: Gen[T6], g7: Gen[T7], g8: Gen[T8])(
     f: (T1,T2,T3,T4,T5,T6,T7,T8) => P)(implicit

--- a/src/main/scala/org/scalacheck/commands/Commands.scala
+++ b/src/main/scala/org/scalacheck/commands/Commands.scala
@@ -215,7 +215,7 @@ trait Commands {
   final def property(threadCount: Int = 1, maxParComb: Int = 1000000): Prop = {
     val suts = collection.mutable.Map.empty[AnyRef,(State,Option[Sut])]
 
-    Prop.forAll(actions(threadCount, maxParComb)) { as =>
+    Prop.forAllShrink(actions(threadCount, maxParComb)) { as =>
       try {
         val sutId = suts.synchronized {
           val initSuts = for((state,None) <- suts.values) yield state


### PR DESCRIPTION
@rickynils @dwijnand 

Sorry if this gets confusing pretty quickly. This is one option for the first change to ScalaCheck to deprecate the forAll Gen functions, but leave the behaviour. Is it what you had in mind?

EDIT: This is based on the original disabling of Shrinking on #440