### PR TITLE
Disable shrinking for forAll with Gen

### DIFF
--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -163,7 +163,7 @@ sealed abstract class Gen[+T] extends Serializable { self =>
     if (lhs == rhs) Prop.proved(prms) else Prop.falsified(prms)
   }
 
-  def !=[U](g: Gen[U]) = Prop.forAll(this)(r => Prop.forAll(g)(_ != r))
+  def !=[U](g: Gen[U]) = Prop.forAllNoShrink(this)(r => Prop.forAllNoShrink(g)(_ != r))
 
   def !==[U](g: Gen[U]) = Prop { prms =>
     // test inequality using a random seed

--- a/src/main/scala/org/scalacheck/Prop.scala
+++ b/src/main/scala/org/scalacheck/Prop.scala
@@ -806,6 +806,7 @@ object Prop {
 
   /** Universal quantifier for an explicit generator. Shrinks failed arguments
    *  with the default shrink function for the type */
+  @deprecated("Use 'forAllNoShrink', shrinking will be disabled for Gen by default in the next release", "1.14.1")
   def forAll[T1,P](
     g1: Gen[T1])(
     f: T1 => P)(implicit
@@ -816,6 +817,7 @@ object Prop {
 
   /** Universal quantifier for two explicit generators. Shrinks failed arguments
    *  with the default shrink function for the type */
+  @deprecated("Use 'forAllNoShrink', shrinking will be disabled for Gen by default in the next release", "1.14.1")
   def forAll[T1,T2,P](
     g1: Gen[T1], g2: Gen[T2])(
     f: (T1,T2) => P)(implicit
@@ -826,6 +828,7 @@ object Prop {
 
   /** Universal quantifier for three explicit generators. Shrinks failed arguments
    *  with the default shrink function for the type */
+  @deprecated("Use 'forAllNoShrink', shrinking will be disabled for Gen by default in the next release", "1.14.1")
   def forAll[T1,T2,T3,P](
     g1: Gen[T1], g2: Gen[T2], g3: Gen[T3])(
     f: (T1,T2,T3) => P)(implicit
@@ -837,6 +840,7 @@ object Prop {
 
   /** Universal quantifier for four explicit generators. Shrinks failed arguments
    *  with the default shrink function for the type */
+  @deprecated("Use 'forAllNoShrink', shrinking will be disabled for Gen by default in the next release", "1.14.1")
   def forAll[T1,T2,T3,T4,P](
     g1: Gen[T1], g2: Gen[T2], g3: Gen[T3], g4: Gen[T4])(
     f: (T1,T2,T3,T4) => P)(implicit
@@ -849,6 +853,7 @@ object Prop {
 
   /** Universal quantifier for five explicit generators. Shrinks failed arguments
    *  with the default shrink function for the type */
+  @deprecated("Use 'forAllNoShrink', shrinking will be disabled for Gen by default in the next release", "1.14.1")
   def forAll[T1,T2,T3,T4,T5,P](
     g1: Gen[T1], g2: Gen[T2], g3: Gen[T3], g4: Gen[T4], g5: Gen[T5])(
     f: (T1,T2,T3,T4,T5) => P)(implicit
@@ -862,6 +867,7 @@ object Prop {
 
   /** Universal quantifier for six explicit generators. Shrinks failed arguments
    *  with the default shrink function for the type */
+  @deprecated("Use 'forAllNoShrink', shrinking will be disabled for Gen by default in the next release", "1.14.1")
   def forAll[T1,T2,T3,T4,T5,T6,P](
     g1: Gen[T1], g2: Gen[T2], g3: Gen[T3], g4: Gen[T4], g5: Gen[T5], g6: Gen[T6])(
     f: (T1,T2,T3,T4,T5,T6) => P)(implicit
@@ -876,6 +882,7 @@ object Prop {
 
   /** Universal quantifier for seven explicit generators. Shrinks failed arguments
    *  with the default shrink function for the type */
+  @deprecated("Use 'forAllNoShrink', shrinking will be disabled for Gen by default in the next release", "1.14.1")
   def forAll[T1,T2,T3,T4,T5,T6,T7,P](
     g1: Gen[T1], g2: Gen[T2], g3: Gen[T3], g4: Gen[T4], g5: Gen[T5], g6: Gen[T6], g7: Gen[T7])(
     f: (T1,T2,T3,T4,T5,T6,T7) => P)(implicit
@@ -891,6 +898,7 @@ object Prop {
 
   /** Universal quantifier for eight explicit generators. Shrinks failed arguments
    *  with the default shrink function for the type */
+  @deprecated("Use 'forAllNoShrink', shrinking will be disabled for Gen by default in the next release", "1.14.1")
   def forAll[T1,T2,T3,T4,T5,T6,T7,T8,P](
     g1: Gen[T1], g2: Gen[T2], g3: Gen[T3], g4: Gen[T4], g5: Gen[T5], g6: Gen[T6], g7: Gen[T7], g8: Gen[T8])(
     f: (T1,T2,T3,T4,T5,T6,T7,T8) => P)(implicit

--- a/src/main/scala/org/scalacheck/Prop.scala
+++ b/src/main/scala/org/scalacheck/Prop.scala
@@ -813,7 +813,7 @@ object Prop {
     p: P => Prop,
     s1: Shrink[T1],
     pp1: T1 => Pretty
-  ): Prop = forAllShrink[T1,P](g1, shrink[T1])(f)
+  ): Prop = forAllNoShrink[T1,P](g1)(f)
 
   /** Universal quantifier for two explicit generators. Shrinks failed arguments
    *  with the default shrink function for the type */

--- a/src/main/scala/org/scalacheck/commands/Commands.scala
+++ b/src/main/scala/org/scalacheck/commands/Commands.scala
@@ -215,7 +215,7 @@ trait Commands {
   final def property(threadCount: Int = 1, maxParComb: Int = 1000000): Prop = {
     val suts = collection.mutable.Map.empty[AnyRef,(State,Option[Sut])]
 
-    Prop.forAll(actions(threadCount, maxParComb)) { as =>
+    Prop.forAllNoShrink(actions(threadCount, maxParComb)) { as =>
       try {
         val sutId = suts.synchronized {
           val initSuts = for((state,None) <- suts.values) yield state

--- a/src/test/scala/org/scalacheck/PropSpecification.scala
+++ b/src/test/scala/org/scalacheck/PropSpecification.scala
@@ -10,7 +10,7 @@
 package org.scalacheck
 
 import Prop.{
-  forAll, falsified, undecided, exception, passed, proved, all,
+  forAll, forAllNoShrink, falsified, undecided, exception, passed, proved, all,
   atLeastOne, sizedProp, someFailing, noneFailing, Undecided, False, True,
   Exception, Proof, throws, BooleanOperators, secure, delay, lzy
 }
@@ -24,7 +24,7 @@ object PropSpecification extends Properties("Prop") {
 
   property("Prop.==> undecided") = forAll { p1: Prop =>
     val g = oneOf(falsified,undecided)
-    forAll(g) { p2 =>
+    forAllNoShrink(g) { p2 =>
       val p3 = (p2 ==> p1)
       p3 == undecided || (p3 == exception && p1 == exception)
     }
@@ -33,7 +33,7 @@ object PropSpecification extends Properties("Prop") {
   property("Prop.==> true") = {
     val g1 = oneOf(proved,falsified,undecided,exception)
     val g2 = oneOf(passed,proved)
-    forAll(g1, g2) { case (p1,p2) =>
+    forAllNoShrink(g1, g2) { case (p1,p2) =>
       val p = p2 ==> p1
       (p == p1) || (p2 == passed && p1 == proved && p == passed)
     }
@@ -56,7 +56,7 @@ object PropSpecification extends Properties("Prop") {
 
   property("Prop.&& Commutativity") = {
     val g = oneOf(proved,passed,falsified,undecided,exception)
-    forAll(g,g) { case (p1,p2) => (p1 && p2) == (p2 && p1) }
+    forAllNoShrink(g,g) { case (p1,p2) => (p1 && p2) == (p2 && p1) }
   }
   property("Prop.&& Exception") = forAll { p: Prop =>
     (p && propException) == exception
@@ -66,7 +66,7 @@ object PropSpecification extends Properties("Prop") {
   }
   property("Prop.&& Identity") = {
     val g = oneOf(proved,passed,falsified,undecided,exception)
-    forAll(g)(p => (p && proved) == p)
+    forAllNoShrink(g)(p => (p && proved) == p)
   }
   property("Prop.&& False") = forAll { p: Prop =>
     val q = p && falsified
@@ -74,7 +74,7 @@ object PropSpecification extends Properties("Prop") {
   }
   property("Prop.&& Undecided") = {
     val g = oneOf(proved,passed,undecided)
-    forAll(g)(p => (p && undecided) == undecided)
+    forAllNoShrink(g)(p => (p && undecided) == undecided)
   }
   property("Prop.&& Right prio") = forAll { (sz: Int, prms: Parameters) =>
     val p = proved.map(_.label("RHS")) && proved.map(_.label("LHS"))
@@ -83,42 +83,42 @@ object PropSpecification extends Properties("Prop") {
 
   property("Prop.|| Commutativity") = {
     val g = oneOf(proved,passed,falsified,undecided,exception)
-    forAll(g,g) { case (p1,p2) => (p1 || p2) == (p2 || p1) }
+    forAllNoShrink(g,g) { case (p1,p2) => (p1 || p2) == (p2 || p1) }
   }
   property("Prop.|| Exception") = forAll { p: Prop =>
     (p || propException()) == exception
   }
   property("Prop.|| Identity") = {
     val g = oneOf(proved,passed,falsified,undecided,exception)
-    forAll(g)(p => (p || falsified) == p)
+    forAllNoShrink(g)(p => (p || falsified) == p)
   }
   property("Prop.|| True") = {
     val g = oneOf(proved,passed,falsified,undecided)
-    forAll(g)(p => (p || proved) == proved)
+    forAllNoShrink(g)(p => (p || proved) == proved)
   }
   property("Prop.|| Undecided") = {
     val g = oneOf(falsified,undecided)
-    forAll(g)(p => (p || undecided) == undecided)
+    forAllNoShrink(g)(p => (p || undecided) == undecided)
   }
 
   property("Prop.++ Commutativity") = {
     val g = oneOf(proved,passed,falsified,undecided,exception)
-    forAll(g,g) { case (p1,p2) => (p1 ++ p2) == (p2 ++ p1) }
+    forAllNoShrink(g,g) { case (p1,p2) => (p1 ++ p2) == (p2 ++ p1) }
   }
   property("Prop.++ Exception") = forAll { p: Prop =>
     (p ++ propException()) == exception
   }
   property("Prop.++ Identity 1") = {
     val g = oneOf(falsified,passed,proved,exception)
-    forAll(g)(p => (p ++ proved) == p)
+    forAllNoShrink(g)(p => (p ++ proved) == p)
   }
   property("Prop.++ Identity 2") = {
     val g = oneOf(proved,passed,falsified,undecided,exception)
-    forAll(g)(p => (p ++ undecided) == p)
+    forAllNoShrink(g)(p => (p ++ undecided) == p)
   }
   property("Prop.++ False") = {
     val g = oneOf(falsified,passed,proved,undecided)
-    forAll(g)(p => (p ++ falsified) == falsified)
+    forAllNoShrink(g)(p => (p ++ falsified) == falsified)
   }
 
   property("undecided") = forAll { prms: Parameters =>
@@ -137,9 +137,9 @@ object PropSpecification extends Properties("Prop") {
     exception(e)(prms).status == Exception(e)
   }
 
-  property("all") = forAll(Gen.nonEmptyListOf(const(proved)))(l => all(l:_*))
+  property("all") = forAllNoShrink(Gen.nonEmptyListOf(const(proved)))(l => all(l:_*))
 
-  property("atLeastOne") = forAll(Gen.nonEmptyListOf(const(proved))) { l =>
+  property("atLeastOne") = forAllNoShrink(Gen.nonEmptyListOf(const(proved))) { l =>
     atLeastOne(l:_*)
   }
 
@@ -150,13 +150,13 @@ object PropSpecification extends Properties("Prop") {
 
   property("sizedProp") = {
     val g = oneOf(passed,falsified,undecided,exception)
-    forAll(g) { p => p == sizedProp(_ => p) }
+    forAllNoShrink(g) { p => p == sizedProp(_ => p) }
   }
 
   property("someFailing") = {
     val g: Gen[Gen[Int]] = oneOf(List(const(1), fail))
     val gs: Gen[List[Gen[Int]]] = listOf(g)
-    forAll(gs) { (gs: List[Gen[Int]]) =>
+    forAllNoShrink(gs) { (gs: List[Gen[Int]]) =>
       someFailing(gs) || gs.forall(_.sample.isDefined)
     }
   }
@@ -164,7 +164,7 @@ object PropSpecification extends Properties("Prop") {
   property("noneFailing") = {
     val g: Gen[Gen[Int]] = oneOf(List(const(1), fail))
     val gs: Gen[List[Gen[Int]]] = listOf(g)
-    forAll(gs) { (gs: List[Gen[Int]]) =>
+    forAllNoShrink(gs) { (gs: List[Gen[Int]]) =>
       noneFailing(gs) || gs.exists(!_.sample.isDefined)
     }
   }
@@ -197,7 +197,7 @@ object PropSpecification extends Properties("Prop") {
   property("prop.useSeed is deterministic (pt. 2)") =
     forAll { (g1: Gen[Int], g2: Gen[Int], g3: Gen[Int], n: Long) =>
       val params = Gen.Parameters.default
-      val p0 = Prop.forAll(g1, g2, g3) { (x, y, z) => x == y && y == z }
+      val p0 = Prop.forAllNoShrink(g1, g2, g3) { (x, y, z) => x == y && y == z }
       val p = p0.useSeed("some name", rng.Seed(n))
       val r1 = p(params).success
       val r2 = p(params).success


### PR DESCRIPTION
@rickynils @dwijnand 

Part 2 of #444 after comments on #440. See the second commit in particular. This is one of the alternative options after bumping the minor version to `1.15.x` (I'm assuming I wouldn't do that in this PR though?). I'm not sure whether keeping the deprecated warnings is going to be popular/desired, in which case we can just stick with #440 and close this.

Apologies if having multiple PRs gets confusing. 