### PR TITLE
Cleanup test for Gen.pick

### DIFF
--- a/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
@@ -214,9 +214,16 @@ object GenSpecification extends Properties("Gen") with GenSpecificationVersionSp
     }
   }
 
+  /**
+   * Expect:
+   * 25% 1, 2, 3
+   * 25% 1, 2, 4
+   * 25% 1, 4, 3
+   * 25% 4, 2, 3
+   */
   property("distributed pick") = {
-    val lst = (0 to 7).toIterable
-    val n = 2
+    val lst = (1 to 4).toIterable
+    val n = 3
     forAll(pick(n, lst)) { xs: collection.Seq[Int] =>
       xs.map { x: Int =>
         Prop.collect(x) {


### PR DESCRIPTION
This is a follow-up to #333.  The test takes 2 from 8 and outputs too much:

```
> Collected test data: 
5% 6, 7
5% 2, 1
4% 4, 5
4% 3, 7
4% 0, 5
4% 6, 2
4% 7, 5
4% 3, 4
4% 4, 2
4% 6, 4
4% 3, 1
4% 5, 1
4% 0, 2
4% 0, 7
4% 7, 4
3% 7, 1
3% 0, 6
3% 5, 6
3% 6, 1
3% 2, 3
3% 2, 7
3% 0, 1
3% 4, 1
3% 5, 3
3% 0, 4
3% 3, 6
3% 5, 2
3% 0, 3
```

As Paul Ford showed in #355, taking 3 from 4 with `Gen.pick` is a sufficient test and only takes 4 lines of output.