### PR TITLE
Reduce weighting of numeric edge cases

### DIFF
--- a/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/GenSpecification.scala
@@ -483,6 +483,17 @@ object GenSpecification extends Properties("Gen") with GenSpecificationVersionSp
   property("negative generators are negative") =
     Prop.forAll(Gen.negNum[Int]) { n => n < 0 }
 
+  property("chooseNum edge cases") = {
+    val minT = -9
+    val maxT = 9
+    val specials = List(minT, -1, 0, 1, maxT);
+    Prop.forAllNoShrink(Gen.chooseNum(minT, maxT)) { x: Int =>
+      Prop.classify(specials.contains(x), "special", "non-special") {
+        true
+      }
+    }
+  }
+
   property("finite duration values are valid") =
     // just make sure it constructs valid finite values that don't throw exceptions
     Prop.forAll(Gen.finiteDuration) { _.isFinite }

--- a/src/main/scala/org/scalacheck/Gen.scala
+++ b/src/main/scala/org/scalacheck/Gen.scala
@@ -832,7 +832,7 @@ object Gen extends GenArities with GenVersionSpecific {
     val basicsAndSpecials = for {
       t <- specials ++ basics if t >= minT && t <= maxT
     } yield (1, const(t))
-    val other = (basicsAndSpecials.length, c.choose(minT, maxT))
+    val other = (9 * basicsAndSpecials.length, c.choose(minT, maxT))
     val allGens = basicsAndSpecials :+ other
     frequency(allGens: _*)
   }


### PR DESCRIPTION
Bill Venners recently gave [a talk](https://www.meetup.com/SF-Scala/events/258488711/) ([video](https://www.youtube.com/watch?v=lKtg-CDVDsI) is online) about property testing with ScalaTest at an SF Scala meetup, and mentioned a defect he found with `Arbitrary[Int]` in ScalaCheck.  He showed in a repl that ScalaCheck gives equal weight to the edge cases  (zero, one, negative one, max, negative max, etc.) as the rest of the numeric range.  This weighting causes edge cases to be 50% of the values in a property test with `Gen.chooseNum`.  This risks running tests repeatedly with the same inputs.

```
+ Gen.chooseNum edge cases: OK, passed 100 tests.
> Collected test data: 
51% non-special
49% special
```

This pull requests reduces the proportion of edge cases to something more reasonable, just 10% of the time.

```
+ Gen.chooseNum edge cases: OK, passed 100 tests.
> Collected test data: 
87% non-special
13% special
```