### PR TITLE
Upgrade to Scala.js 1.0.0-M6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ env:
     - PLATFORM=jvm SBT_PARALLEL=true  WORKERS=4 DEPLOY=false
     - PLATFORM=jvm SBT_PARALLEL=false WORKERS=4 DEPLOY=false
     - PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true
-    - PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true SCALAJS_VERSION=1.0.0-M3
+    - PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true SCALAJS_VERSION=1.0.0-M6
 sudo: false
 
 matrix:
@@ -49,7 +49,7 @@ matrix:
       - for d in */ ; do cd "$d" && sbt test:compile && cd ../ ; done
   exclude:
     - scala: 2.10.7
-      env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true SCALAJS_VERSION=1.0.0-M3
+      env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true SCALAJS_VERSION=1.0.0-M6
     - jdk: openjdk11
       scala: 2.10.7
     - jdk: openjdk11

--- a/build.sbt
+++ b/build.sbt
@@ -126,10 +126,7 @@ lazy val js = project.in(file("js"))
   .settings(sharedSettings: _*)
   .settings(
     scalaJSStage in Global := FastOptStage,
-    libraryDependencies += "org.scala-js" %% "scalajs-test-interface" % scalaJSVersion,
-    // because Scala.js deprecated TestUtils but we haven't worked around that yet,
-    // see https://github.com/rickynils/scalacheck/pull/435#issuecomment-430405390
-    scalacOptions ~= (_ filterNot (_ == "-Xfatal-warnings"))
+    libraryDependencies += "org.scala-js" %% "scalajs-test-interface" % scalaJSVersion
   )
   .enablePlugins(ScalaJSPlugin)
 


### PR DESCRIPTION
Resubmission of #459, with a first commit not to use the deprecated `TestUtils` anymore.