### PR TITLE
Scala 2.13.0-RC2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ scala:
   - 2.10.7
   - 2.11.12
   - 2.12.6
-  - 2.13.0-M5
+  - 2.13.0-RC2
 jdk:
   - oraclejdk8
 env:
@@ -28,7 +28,7 @@ env:
     - PLATFORM=jvm SBT_PARALLEL=true  WORKERS=4 DEPLOY=false
     - PLATFORM=jvm SBT_PARALLEL=false WORKERS=4 DEPLOY=false
     - PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true
-    - PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true SCALAJS_VERSION=1.0.0-M3
+    - PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true SCALAJS_VERSION=1.0.0-M7
 sudo: false
 
 matrix:
@@ -47,6 +47,6 @@ matrix:
       - for d in */ ; do cd "$d" && sbt test:compile && cd ../ ; done
   exclude:
     - scala: 2.10.7
-      env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true SCALAJS_VERSION=1.0.0-M3
-    - scala: 2.13.0-M5
-      env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true SCALAJS_VERSION=0.6.25
+      env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true SCALAJS_VERSION=1.0.0-M7
+    - scala: 2.13.0-RC2
+      env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ lazy val travisCommit = Option(System.getenv().get("TRAVIS_COMMIT"))
 
 lazy val scalaVersionSettings = Seq(
   scalaVersion := "2.12.6",
-  crossScalaVersions := Seq("2.10.7", "2.11.12", "2.13.0-RC1", scalaVersion.value),
+  crossScalaVersions := Seq("2.10.7", "2.11.12", "2.13.0-RC2", scalaVersion.value),
   scalaMajorVersion := {
     val v = scalaVersion.value
     CrossVersion.partialVersion(v).map(_._2.toInt).getOrElse {


### PR DESCRIPTION
Move the build to 2.13.0-RC2 on the 1.14.0 brach.

It may fix the issues with Scala.js 1.0.0-M7, as well, by cherry-picking #460.