### PR TITLE
Fix 1.14.0 MiMa for Scala.js

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -132,6 +132,13 @@ lazy val js = project.in(file("js"))
   .settings(
     scalaJSStage in Global := FastOptStage,
     libraryDependencies += "org.scala-js" %% "scalajs-test-interface" % scalaJSVersion,
+    mimaPreviousArtifacts := {
+      val isScalaJSMilestone: Boolean =
+        Option(System.getenv("SCALAJS_VERSION")).filter(_.startsWith("1.0.0-M")).isDefined
+      // TODO: re-enable MiMa for 2.13 once there is a release out
+      if (scalaMajorVersion.value == 13 || isScalaJSMilestone) Set()
+      else Set("org.scalacheck" %%% "scalacheck" % "1.14.0")
+    },
     // because Scala.js deprecated TestUtils but we haven't worked around that yet,
     // see https://github.com/rickynils/scalacheck/pull/435#issuecomment-430405390
     scalacOptions ~= (_ filterNot (_ == "-Xfatal-warnings"))


### PR DESCRIPTION
I'm not sure how capable Migration Manager is about finding binary changes with Scala.js artifacts or not, but adding a setting for it at least allows ScalaCheck to publish Scala.js artifacts rather than MiMa needlessly failing.

I tested this, by running the following locally:

```
sbt> ;++2.12.6;js/package
sbt> ;++2.13.0-RC2;js/package
```

Starting sbt with `env SCALAJS_VERSION=1.0.0-M8 sbt`.

This should help with publishing 2.12 and 2.13 artifacts for Scala.js 1.0.0-M8 per #474.