### PR TITLE
Make Pretty.break tail recursive

### DIFF
--- a/src/main/scala/org/scalacheck/util/Pretty.scala
+++ b/src/main/scala/org/scalacheck/util/Pretty.scala
@@ -51,9 +51,23 @@ object Pretty {
     if(s.length >= length) s
     else s + List.fill(length-s.length)(c).mkString
 
-  def break(s: String, lead: String, length: Int): String =
-    if(s.length <= length || length <= 0) s
-    else s.substring(0, length) / break(lead+s.substring(length), lead, length)
+  def break(s: String, lead: String, length: Int): String = {
+    require(lead.length < length, "`lead.length` must be shorter than line `length`")
+
+    @annotation.tailrec
+    def loop(s: String, lead: String, length: Int, result: StringBuilder): StringBuilder = {
+      if (s.length <= length || length <= 0) result.append(s)
+      else {
+        result.append(s.substring(0, length)).append("\n")
+        loop(lead + s.substring(length), lead, length, result)
+      }
+    }
+
+    val builder = new StringBuilder
+    loop(s, lead, length, builder)
+
+    builder.result()
+  }
 
   def format(s: String, lead: String, trail: String, width: Int) =
     // was just `s.lines....`, but on JDK 11 we hit scala/bug#11125


### PR DESCRIPTION
Hi, we have a rather large test, that would trigger stack overflow from `Prettybreak`. This should fix it.

Tried to keep to similar style. The only functional change is the added requirement for `lead.length`.

No tests submitted, since it seems `util.Pretty` is not tested a lot. I'm leaning towards adding them, but don't want change too much, so waiting for yay/nay whether to do it.