### PR TITLE
Publish Scala 2.13.0 for 1.14.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ scala:
   - 2.10.7
   - 2.11.12
   - 2.12.6
-  - 2.13.0-RC2
+  - 2.13.0
 jdk:
   - oraclejdk8
 env:
@@ -28,7 +28,7 @@ env:
     - PLATFORM=jvm SBT_PARALLEL=true  WORKERS=4 DEPLOY=false
     - PLATFORM=jvm SBT_PARALLEL=false WORKERS=4 DEPLOY=false
     - PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true
-    - PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true SCALAJS_VERSION=1.0.0-M7
+    - PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true SCALAJS_VERSION=1.0.0-M8
 sudo: false
 
 matrix:
@@ -47,6 +47,6 @@ matrix:
       - for d in */ ; do cd "$d" && sbt test:compile && cd ../ ; done
   exclude:
     - scala: 2.10.7
-      env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true SCALAJS_VERSION=1.0.0-M7
-    - scala: 2.13.0-RC2
+      env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true SCALAJS_VERSION=1.0.0-M8
+    - scala: 2.13.0
       env: PLATFORM=js  SBT_PARALLEL=true  WORKERS=1 DEPLOY=true

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ lazy val travisCommit = Option(System.getenv().get("TRAVIS_COMMIT"))
 
 lazy val scalaVersionSettings = Seq(
   scalaVersion := "2.12.6",
-  crossScalaVersions := Seq("2.10.7", "2.11.12", "2.13.0-RC2", scalaVersion.value),
+  crossScalaVersions := Seq("2.10.7", "2.11.12", "2.13.0", scalaVersion.value),
   scalaMajorVersion := {
     val v = scalaVersion.value
     CrossVersion.partialVersion(v).map(_._2.toInt).getOrElse {
@@ -68,11 +68,10 @@ lazy val sharedSettings = MimaSettings.settings ++ scalaVersionSettings ++ Seq(
     "-encoding", "UTF-8",
     "-feature",
     "-unchecked",
-    "-Xfuture",
     "-Ywarn-dead-code",
     "-Ywarn-numeric-widen") ++ {
     val modern = Seq("-Xlint:-unused", "-Ywarn-unused:-patvars,-implicits,-locals,-privates,-explicits")
-    val removed = Seq("-Ywarn-inaccessible", "-Ywarn-nullary-override", "-Ywarn-nullary-unit")
+    val removed = Seq("-Ywarn-inaccessible", "-Ywarn-nullary-override", "-Ywarn-nullary-unit", "-Xfuture")
     val removedModern = Seq("-Ywarn-infer-any", "-Ywarn-unused-import")
     scalaMajorVersion.value match {
       case 10 => Seq("-Xfatal-warnings", "-Xlint") ++ removed

--- a/examples/scalajs/project/build.sbt
+++ b/examples/scalajs/project/build.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.25")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.28")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.3
+sbt.version=1.2.8

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -3,7 +3,7 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.2.0")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
 
 val scalaJSVersion =
-  Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.27")
+  Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.28")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 


### PR DESCRIPTION
I verified that the following works locally from sbt:

```
> ++2.13.0
> jvm/package
> js/package
```

That will publish Scala 2.13 and Scalajs 0.6.x for 2.13.

Publishing Scalajs for 1.0.0-M8 for 2.12 and 2.13, also works.  First, start sbt with:

    $ env SCALAJS_VERSION=1.0.0-M8 sbt

Then:

```
> ++2.12.6
> js/package
> ++2.13.0
> js/package
```

May require #475 for publish to work, though.