### PR TITLE
Add test for Arbitrary recursive Option

### DIFF
--- a/jvm/src/test/scala/org/scalacheck/ArbitrarySpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/ArbitrarySpecification.scala
@@ -23,6 +23,23 @@ object ArbitrarySpecification extends Properties("Arbitrary") {
   property("arbOption coverage") =
     exists(genOptionUnits) { case (a, b) => a.isDefined != b.isDefined }
 
+  private final case class RecursiveOption(opt: Option[RecursiveOption])
+
+  implicit private[this] def arbRecursiveOption: Arbitrary[RecursiveOption] =
+    Arbitrary(genRecursiveOption)
+
+  private[this] def genRecursiveOption: Gen[RecursiveOption] =
+    Gen.oneOf(
+      Gen.const(RecursiveOption(None)),
+      Gen.delay(Arbitrary.arbitrary[Option[RecursiveOption]] // !
+        .map(RecursiveOption(_))))
+
+  property("arbitrary[RecursiveOption].passed") = {
+    Prop.forAll { recOpt: RecursiveOption =>
+      Prop.passed
+    }
+  }
+
   property("arbEnum") = {
     Gen.listOfN(100, arbitrary[TimeUnit]).sample.get.toSet == TimeUnit.values.toSet
   }


### PR DESCRIPTION
This is something that came up in #485 as a result of changing `Arbitrary.arbitrary[Option]` for #401.  It seems that tests that had a generator of `X(Option[X])` with faulty recursion were previously able to get away with it.  Presumably, this was because `Arbitrary.arbOption` was more biased to `None`.