### PR TITLE
Stack overflow regression of recursive arbOption

### DIFF
--- a/jvm/src/test/scala/org/scalacheck/ArbitrarySpecification.scala
+++ b/jvm/src/test/scala/org/scalacheck/ArbitrarySpecification.scala
@@ -23,6 +23,19 @@ object ArbitrarySpecification extends Properties("Arbitrary") {
   property("arbOption coverage") =
     exists(genOptionUnits) { case (a, b) => a.isDefined != b.isDefined }
 
+  private[this] final case class Recur(opt: Option[Recur])
+
+  private[this] implicit def arbRecur: Arbitrary[Recur] = Arbitrary {
+    Arbitrary.arbitrary[Option[Recur]]
+      .map(Recur(_))
+  }
+    
+  property("arbitrary[Recur]") = {
+    Prop.forAll { recOpt: Recur =>
+      Prop.passed
+    }
+  }
+
   property("arbEnum") = {
     Gen.listOfN(100, arbitrary[TimeUnit]).sample.get.toSet == TimeUnit.values.toSet
   }

--- a/src/main/scala/org/scalacheck/Arbitrary.scala
+++ b/src/main/scala/org/scalacheck/Arbitrary.scala
@@ -336,7 +336,7 @@ private[scalacheck] sealed trait ArbitraryLowPriority {
 
   /** Arbitrary instance of the Option type */
   implicit def arbOption[T](implicit a: Arbitrary[T]): Arbitrary[Option[T]] =
-    Arbitrary(Gen.option(a.arbitrary))
+    Arbitrary(Gen.option(Gen.delay(a.arbitrary)))
 
   /** Arbitrary instance of the Either type */
   implicit def arbEither[T, U](implicit at: Arbitrary[T], au: Arbitrary[U]): Arbitrary[Either[T, U]] =


### PR DESCRIPTION
The change in #408 broke definitions of `Arbitrary[X]` where X is a class with a recursive `Option` value.  ~~One potential fix is to rollback #286 that was released in 1.14.0.~~  Alternatively, we can just call-by-name the implicit `Arbitrary` of `arbOption` with `Gen.delay`, in case it is recursive.