### PR TITLE
Clean up warnings and scalac options.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,23 +62,40 @@ lazy val sharedSettings = MimaSettings.settings ++ scalaVersionSettings ++ Seq(
 
   javacOptions += "-Xmx1024M",
 
-  scalacOptions ++= Seq(
-    "-deprecation",
-    "-encoding", "UTF-8",
-    "-feature",
-    "-unchecked",
-    "-Xfuture",
-    "-Ywarn-dead-code",
-    "-Ywarn-numeric-widen") ++ {
-    val modern = Seq("-Xlint:-unused", "-Ywarn-unused:-patvars,-implicits,-locals,-privates,-explicits")
-    val removed = Seq("-Ywarn-inaccessible", "-Ywarn-nullary-override", "-Ywarn-nullary-unit")
-    val removedModern = Seq("-Ywarn-infer-any", "-Ywarn-unused-import")
-    scalaMajorVersion.value match {
-      case 10 => Seq("-Xfatal-warnings", "-Xlint") ++ removed
-      case 11 => Seq("-Xfatal-warnings", "-Xlint", "-Ywarn-infer-any", "-Ywarn-unused-import") ++ removed
-      case 12 => "-Xfatal-warnings" +: (modern ++ removed ++ removedModern)
-      case 13 => modern
-    }
+  scalacOptions ++= {
+    val all =
+      "-encoding" :: "UTF-8" ::
+      "-feature" ::
+      "-unchecked" ::
+      "-Ywarn-dead-code" ::
+      "-Ywarn-numeric-widen" ::
+      Nil
+
+    val before213 =
+      "-Ywarn-inaccessible" ::
+      "-Ywarn-nullary-override" ::
+      "-Ywarn-nullary-unit" ::
+      "-Xfuture" ::
+      "-Xfatal-warnings" ::
+      "-deprecation" ::
+      Nil
+
+    val only212 =
+      "-Ywarn-infer-any" ::
+      "-Ywarn-unused-import" ::
+      Nil
+
+    val since212 =
+      "-Xlint:-unused" ::
+      "-Ywarn-unused:-patvars,-implicits,-locals,-privates,-explicits" ::
+      Nil
+
+    all ::: (scalaMajorVersion.value match {
+      case 10 => "-Xlint" :: before213
+      case 11 => "-Xlint" :: "-Ywarn-infer-any" :: "-Ywarn-unused-import" :: before213
+      case 12 => before213 ::: only212 ::: since212
+      case 13 => since212
+    })
   },
 
   // HACK: without these lines, the console is basically unusable,

--- a/build.sbt
+++ b/build.sbt
@@ -64,22 +64,21 @@ lazy val sharedSettings = MimaSettings.settings ++ scalaVersionSettings ++ Seq(
 
   // 2.10 - 2.13
   scalacOptions ++= {
-    def mk(min: Int, max: Int)(strs: String*): (Int => Boolean, Seq[String]) =
-      ((n: Int) => min <= n && n <= max, strs)
+    def mk(r: Range)(strs: String*): Int => Seq[String] =
+      (n: Int) => if (r.contains(n)) strs else Seq.empty
 
-    val groups: Seq[(Int => Boolean, Seq[String])] = Seq(
-      mk(10, 11)("-Xlint"),
-      mk(10, 12)("-Ywarn-inaccessible", "-Ywarn-nullary-override",
+    val groups: Seq[Int => Seq[String]] = Seq(
+      mk(10 to 11)("-Xlint"),
+      mk(10 to 12)("-Ywarn-inaccessible", "-Ywarn-nullary-override",
         "-Ywarn-nullary-unit", "-Xfuture", "-Xfatal-warnings", "-deprecation"),
-      mk(10, 13)("-encoding", "UTF-8", "-feature", "-unchecked",
+      mk(10 to 13)("-encoding", "UTF-8", "-feature", "-unchecked",
         "-Ywarn-dead-code", "-Ywarn-numeric-widen"),
-      mk(11, 12)("-Ywarn-infer-any", "-Ywarn-unused-import"),
-      mk(12, 13)("-Xlint:-unused",
+      mk(11 to 12)("-Ywarn-infer-any", "-Ywarn-unused-import"),
+      mk(12 to 13)("-Xlint:-unused",
         "-Ywarn-unused:-patvars,-implicits,-locals,-privates,-explicits"))
 
     val n = scalaMajorVersion.value
-
-    groups.flatMap { case (p, strs) => if (p(n)) strs else Seq.empty }
+    groups.flatMap(f => f(n))
   },
 
   // HACK: without these lines, the console is basically unusable,

--- a/src/test/scala/org/scalacheck/ShrinkSpecification.scala
+++ b/src/test/scala/org/scalacheck/ShrinkSpecification.scala
@@ -11,7 +11,6 @@ package org.scalacheck
 
 import Prop.{forAll, forAllNoShrink, BooleanOperators}
 import Shrink.shrink
-import ScalaVersionSpecific._
 
 import scala.concurrent.duration.{Duration, FiniteDuration}
 


### PR DESCRIPTION
This removes -deprecation warnings for 2.13 (since there are over 100
of them). It also tries to make it a bit easier to see which options
are used for which versions. Finally it removes an unused import.

I did this as an isolated PR because it's small and easy to review.