### PR TITLE
Automate publishing to scalacheck.org website

### DIFF
--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -1,0 +1,35 @@
+name: Publish Site
+
+on:
+  push:
+    branches:
+      - website
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Install nix
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: "experimental-features = nix-command flakes"
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+        shell: bash
+
+      - name: Execute push-site.sh
+        run: bash ./push-site.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Creates "Publish Site" workflow action that gets triggerred on every push to the [website](https://github.com/typelevel/scalacheck/tree/website) branch.
The action generates the docs based on its current state, then pushed the generated content to the [gh-pages](https://github.com/typelevel/scalacheck/tree/gh-pages) branch which is then gets reflected on [scalacheck.org](https://scalacheck.org).

The action was tested in my [fork](https://github.com/satorg/typelevel.scalacheck/actions) – seems working correctly.

Prerequisites:
- Make sure that actions [actions/checkout@v5](https://github.com/actions/checkout) and [cachix/install-nix-action@v31](https://github.com/cachix/install-nix-action) are allowed for this repository.
