### PR TITLE
Use Scala Native `test-interface-sbt-defs` instead of `test-interface`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -107,7 +107,7 @@ lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   )
   .nativeSettings(
     libraryDependencies ++= Seq(
-      "org.scala-native" %%% "test-interface" % nativeVersion
+      "org.scala-native" %%% "test-interface-sbt-defs" % nativeVersion
     ),
     tlVersionIntroduced := List("2.12", "2.13", "3").map(_ -> "1.18.0").toMap
   )


### PR DESCRIPTION
See https://github.com/scala-native/scala-native/issues/4844

Testing libraries and frameworks should depend on Scala Native's `test-interface-sbt-defs`, not `test-interface`.
 - `test-interface-sbt-defs` defines a common interface for unit tests. It follows `early-semver` versioning.
 - `test-interface` is a server implementation that must match the version of the Scala Native plugin. It follows `strict` versioning.

This was picked up by SBT [1.12.10](https://eed3si9n.com/sbt-1.12.10), which added eviction checks for test dependencies.


## How to reproduce

You can reproduce the problem in the [weaver-test](https://github.com/typelevel/weaver-test) repo. Set `evictionWarningOptions` to cover the `Test` configuration:

```
ThisBuild / evictionWarningOptions := (ThisBuild / evictionWarningOptions).value
  .withConfigurations(List(Compile, Test))
```

and run `sbt "scalacheckNative / update"`.